### PR TITLE
Add NeoForge data generation bootstrap

### DIFF
--- a/src/main/java/appeng/data/AE2DataGen.java
+++ b/src/main/java/appeng/data/AE2DataGen.java
@@ -1,0 +1,58 @@
+package appeng.data;
+
+import net.minecraft.core.HolderLookup;
+import net.minecraft.data.DataGenerator;
+import net.minecraft.data.PackOutput;
+import net.neoforged.neoforge.common.data.ExistingFileHelper;
+import net.neoforged.neoforge.data.event.GatherDataEvent;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+
+import java.util.concurrent.CompletableFuture;
+
+import appeng.core.AppEng;
+import appeng.data.providers.AEBiomeModifierProvider;
+import appeng.data.providers.AEBlockStateProvider;
+import appeng.data.providers.AEItemModelProvider;
+import appeng.data.providers.AELangProvider;
+import appeng.data.providers.AELootTableProvider;
+import appeng.data.providers.AERecipeProvider;
+import appeng.data.providers.AETagProviders;
+
+@EventBusSubscriber(modid = AppEng.MOD_ID, bus = EventBusSubscriber.Bus.MOD)
+public final class AE2DataGen {
+    private AE2DataGen() {
+    }
+
+    @SubscribeEvent
+    public static void onGatherData(final GatherDataEvent event) {
+        final DataGenerator generator = event.getGenerator();
+        final PackOutput packOutput = generator.getPackOutput();
+        final ExistingFileHelper existing = event.getExistingFileHelper();
+        final CompletableFuture<HolderLookup.Provider> lookup = event.getLookupProvider();
+
+        final boolean includeClient = event.includeClient();
+        final boolean includeServer = event.includeServer();
+
+        if (includeServer) {
+            final AETagProviders.BlockTags blocks = new AETagProviders.BlockTags(packOutput, lookup);
+            generator.addProvider(true, blocks);
+            generator.addProvider(true, new AETagProviders.ItemTags(packOutput, lookup, blocks));
+
+            generator.addProvider(true, new AELootTableProvider(packOutput, lookup));
+
+            generator.addProvider(true, new AERecipeProvider(packOutput));
+        }
+
+        if (includeClient) {
+            generator.addProvider(true, new AEBlockStateProvider(packOutput, existing));
+            generator.addProvider(true, new AEItemModelProvider(packOutput, existing));
+
+            generator.addProvider(true, new AELangProvider(packOutput, "en_us"));
+        }
+
+        if (includeServer) {
+            generator.addProvider(true, new AEBiomeModifierProvider(packOutput, lookup));
+        }
+    }
+}

--- a/src/main/java/appeng/data/providers/AEBiomeModifierProvider.java
+++ b/src/main/java/appeng/data/providers/AEBiomeModifierProvider.java
@@ -1,0 +1,20 @@
+package appeng.data.providers;
+
+import java.util.concurrent.CompletableFuture;
+
+import net.minecraft.core.HolderLookup;
+import net.minecraft.data.PackOutput;
+import net.neoforged.neoforge.common.data.BiomeModifierProvider;
+
+import appeng.core.AppEng;
+
+public final class AEBiomeModifierProvider extends BiomeModifierProvider {
+    public AEBiomeModifierProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> lookup) {
+        super(output, AppEng.MOD_ID, lookup);
+    }
+
+    @Override
+    protected void registerModifiers(HolderLookup.Provider registries) {
+        // add("add_quartz_ore", yourPlacedFeatureKey, yourBiomeSelector);
+    }
+}

--- a/src/main/java/appeng/data/providers/AEBlockLoot.java
+++ b/src/main/java/appeng/data/providers/AEBlockLoot.java
@@ -1,0 +1,24 @@
+package appeng.data.providers;
+
+import java.util.Set;
+
+import net.minecraft.world.flag.FeatureFlags;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.data.loot.BlockLootSubProvider;
+
+public final class AEBlockLoot extends BlockLootSubProvider {
+    public AEBlockLoot() {
+        super(Set.of(), FeatureFlags.REGISTRY.allFlags());
+    }
+
+    @Override
+    protected void generate() {
+        // dropSelf(AEBlocks.QUARTZ_ORE.get());
+    }
+
+    @Override
+    protected Iterable<Block> getKnownBlocks() {
+        // return AEBlocks.BLOCKS.getEntries().stream().map(RegistryObject::get)::iterator;
+        return Set.<Block>of();
+    }
+}

--- a/src/main/java/appeng/data/providers/AEBlockStateProvider.java
+++ b/src/main/java/appeng/data/providers/AEBlockStateProvider.java
@@ -1,0 +1,18 @@
+package appeng.data.providers;
+
+import net.minecraft.data.PackOutput;
+import net.neoforged.neoforge.client.model.generators.BlockStateProvider;
+import net.neoforged.neoforge.common.data.ExistingFileHelper;
+
+import appeng.core.AppEng;
+
+public final class AEBlockStateProvider extends BlockStateProvider {
+    public AEBlockStateProvider(PackOutput output, ExistingFileHelper existing) {
+        super(output, AppEng.MOD_ID, existing);
+    }
+
+    @Override
+    protected void registerStatesAndModels() {
+        // simpleBlock(AEBlocks.QUARTZ_ORE.get());
+    }
+}

--- a/src/main/java/appeng/data/providers/AEItemModelProvider.java
+++ b/src/main/java/appeng/data/providers/AEItemModelProvider.java
@@ -1,0 +1,19 @@
+package appeng.data.providers;
+
+import net.minecraft.data.PackOutput;
+import net.neoforged.neoforge.client.model.generators.ItemModelProvider;
+import net.neoforged.neoforge.common.data.ExistingFileHelper;
+
+import appeng.core.AppEng;
+
+public final class AEItemModelProvider extends ItemModelProvider {
+    public AEItemModelProvider(PackOutput output, ExistingFileHelper existing) {
+        super(output, AppEng.MOD_ID, existing);
+    }
+
+    @Override
+    protected void registerModels() {
+        // withExistingParent(AEItems.SOMETHING.getId().getPath(), modLoc("item/generated"))
+        //     .texture("layer0", modLoc("item/something"));
+    }
+}

--- a/src/main/java/appeng/data/providers/AELangProvider.java
+++ b/src/main/java/appeng/data/providers/AELangProvider.java
@@ -1,0 +1,17 @@
+package appeng.data.providers;
+
+import net.minecraft.data.PackOutput;
+import net.neoforged.neoforge.common.data.LanguageProvider;
+
+import appeng.core.AppEng;
+
+public final class AELangProvider extends LanguageProvider {
+    public AELangProvider(PackOutput output, String locale) {
+        super(output, AppEng.MOD_ID, locale);
+    }
+
+    @Override
+    protected void addTranslations() {
+        // add("item." + AppEng.MOD_ID + ".certus_quartz", "Certus Quartz");
+    }
+}

--- a/src/main/java/appeng/data/providers/AELootTableProvider.java
+++ b/src/main/java/appeng/data/providers/AELootTableProvider.java
@@ -1,0 +1,16 @@
+package appeng.data.providers;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import net.minecraft.core.HolderLookup;
+import net.minecraft.data.PackOutput;
+import net.minecraft.data.loot.LootTableProvider;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParamSets;
+
+public final class AELootTableProvider extends LootTableProvider {
+    public AELootTableProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> lookup) {
+        super(output, Set.of(), List.of(new SubProviderEntry(AEBlockLoot::new, LootContextParamSets.BLOCK)), lookup);
+    }
+}

--- a/src/main/java/appeng/data/providers/AERecipeProvider.java
+++ b/src/main/java/appeng/data/providers/AERecipeProvider.java
@@ -1,0 +1,22 @@
+package appeng.data.providers;
+
+import net.minecraft.data.PackOutput;
+import net.minecraft.data.recipes.RecipeOutput;
+import net.minecraft.data.recipes.RecipeProvider;
+
+public final class AERecipeProvider extends RecipeProvider {
+    public AERecipeProvider(PackOutput output) {
+        super(output);
+    }
+
+    @Override
+    protected void buildRecipes(RecipeOutput out) {
+        // ShapedRecipeBuilder.shaped(RecipeCategory.MISC, AEItems.CERTUS_QUARTZ.get())
+        //     .define('#', Items.QUARTZ)
+        //     .pattern(" # ")
+        //     .pattern("###")
+        //     .pattern(" # ")
+        //     .unlockedBy("has_quartz", has(Items.QUARTZ))
+        //     .save(out);
+    }
+}

--- a/src/main/java/appeng/data/providers/AETagProviders.java
+++ b/src/main/java/appeng/data/providers/AETagProviders.java
@@ -1,0 +1,38 @@
+package appeng.data.providers;
+
+import java.util.concurrent.CompletableFuture;
+
+import net.minecraft.core.HolderLookup;
+import net.minecraft.data.PackOutput;
+import net.neoforged.neoforge.common.data.BlockTagsProvider;
+import net.neoforged.neoforge.common.data.ItemTagsProvider;
+
+import appeng.core.AppEng;
+
+public final class AETagProviders {
+    private AETagProviders() {
+    }
+
+    public static final class BlockTags extends BlockTagsProvider {
+        public BlockTags(PackOutput output, CompletableFuture<HolderLookup.Provider> lookup) {
+            super(output, lookup, AppEng.MOD_ID);
+        }
+
+        @Override
+        protected void addTags(HolderLookup.Provider provider) {
+            // Example:
+            // tag(net.minecraft.tags.BlockTags.MINEABLE_WITH_PICKAXE).add(AEBlocks.QUARTZ_ORE.get());
+        }
+    }
+
+    public static final class ItemTags extends ItemTagsProvider {
+        public ItemTags(PackOutput output, CompletableFuture<HolderLookup.Provider> lookup, BlockTags blockTags) {
+            super(output, lookup, blockTags.contentsGetter(), AppEng.MOD_ID);
+        }
+
+        @Override
+        protected void addTags(HolderLookup.Provider provider) {
+            // Mirror block → item tags or add custom item tags.
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a GatherDataEvent bootstrap that wires up new datagen providers for AE2
- add skeleton providers for tags, loot tables, recipes, blockstates, item models, language, and biome modifiers

## Testing
- not run (datagen only)


------
https://chatgpt.com/codex/tasks/task_e_68def05766548327954d46c144055a21