### PR TITLE
Add scaffold for payload-based network handlers

### DIFF
--- a/src/main/java/appeng/core/network/AE2Network.java
+++ b/src/main/java/appeng/core/network/AE2Network.java
@@ -1,0 +1,43 @@
+package appeng.core.network;
+
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
+import net.neoforged.neoforge.network.registration.LoginPayloadRegistrar;
+import net.neoforged.neoforge.network.registration.PlayPayloadRegistrar;
+
+import appeng.core.AppEng;
+import appeng.core.network.payload.AE2ActionC2SPayload;
+import appeng.core.network.payload.AE2HelloS2CPayload;
+import appeng.core.network.payload.AE2LoginAckC2SPayload;
+import appeng.core.network.payload.AE2LoginSyncS2CPayload;
+
+@EventBusSubscriber(modid = AppEng.MOD_ID, bus = EventBusSubscriber.Bus.MOD)
+public final class AE2Network {
+    private AE2Network() {
+    }
+
+    // Protocol version for play payloads. Update cautiously.
+    public static final String PLAY_PROTOCOL = "1";
+
+    @SubscribeEvent
+    public static void register(final RegisterPayloadHandlersEvent event) {
+        // Play (in-game) payloads
+        final PlayPayloadRegistrar play = event.registrar(PLAY_PROTOCOL);
+
+        // S2C example
+        play.playToClient(AE2HelloS2CPayload.TYPE, AE2HelloS2CPayload.STREAM_CODEC,
+                AE2NetworkHandlers::handleHelloClient);
+
+        // C2S example
+        play.playToServer(AE2ActionC2SPayload.TYPE, AE2ActionC2SPayload.STREAM_CODEC,
+                AE2NetworkHandlers::handleActionServer);
+
+        // Login (handshake) payloads
+        final LoginPayloadRegistrar login = event.login();
+        login.register(AE2LoginSyncS2CPayload.TYPE, AE2LoginSyncS2CPayload.STREAM_CODEC,
+                AE2NetworkHandlers::handleLoginSyncClient);
+        login.register(AE2LoginAckC2SPayload.TYPE, AE2LoginAckC2SPayload.STREAM_CODEC,
+                AE2NetworkHandlers::handleLoginAckServer);
+    }
+}

--- a/src/main/java/appeng/core/network/AE2NetworkHandlers.java
+++ b/src/main/java/appeng/core/network/AE2NetworkHandlers.java
@@ -1,0 +1,45 @@
+package appeng.core.network;
+
+import net.neoforged.neoforge.network.handling.IPayloadContext;
+
+import appeng.core.network.payload.AE2ActionC2SPayload;
+import appeng.core.network.payload.AE2HelloS2CPayload;
+import appeng.core.network.payload.AE2LoginAckC2SPayload;
+import appeng.core.network.payload.AE2LoginSyncS2CPayload;
+
+public final class AE2NetworkHandlers {
+    private AE2NetworkHandlers() {
+    }
+
+    // S2C handler runs on client
+    public static void handleHelloClient(final AE2HelloS2CPayload payload, final IPayloadContext ctx) {
+        // Ensure on main client thread
+        ctx.enqueueWork(() -> {
+            // Example: update a client-side cache or open a screen
+            // AE2ClientCache.setGreeting(payload.message());
+        });
+        ctx.setPacketHandled(true);
+    }
+
+    // C2S handler runs on server
+    public static void handleActionServer(final AE2ActionC2SPayload payload, final IPayloadContext ctx) {
+        // Validate and perform server-side action
+        // AE2ServerActions.perform(payload, ctx.player());
+        ctx.setPacketHandled(true);
+    }
+
+    // Login S2C -> client
+    public static void handleLoginSyncClient(final AE2LoginSyncS2CPayload payload, final IPayloadContext ctx) {
+        ctx.enqueueWork(() -> {
+            // Apply synced server settings before play starts
+            // AE2ClientConfig.apply(payload.configBlob());
+        });
+        ctx.setPacketHandled(true);
+    }
+
+    // Login C2S -> server
+    public static void handleLoginAckServer(final AE2LoginAckC2SPayload payload, final IPayloadContext ctx) {
+        // Optionally record that the client accepted sync
+        ctx.setPacketHandled(true);
+    }
+}

--- a/src/main/java/appeng/core/network/AE2Packets.java
+++ b/src/main/java/appeng/core/network/AE2Packets.java
@@ -1,0 +1,20 @@
+package appeng.core.network;
+
+import net.minecraft.server.level.ServerPlayer;
+import net.neoforged.neoforge.network.PacketDistributor;
+
+import appeng.core.network.payload.AE2ActionC2SPayload;
+import appeng.core.network.payload.AE2HelloS2CPayload;
+
+public final class AE2Packets {
+    private AE2Packets() {
+    }
+
+    public static void sendHello(ServerPlayer player, String msg) {
+        PacketDistributor.sendToPlayer(player, new AE2HelloS2CPayload(msg));
+    }
+
+    public static void sendActionToServer(int id, long value) {
+        PacketDistributor.sendToServer(new AE2ActionC2SPayload(id, value));
+    }
+}

--- a/src/main/java/appeng/core/network/payload/AE2ActionC2SPayload.java
+++ b/src/main/java/appeng/core/network/payload/AE2ActionC2SPayload.java
@@ -1,0 +1,25 @@
+package appeng.core.network.payload;
+
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceLocation;
+
+import appeng.core.AppEng;
+
+public record AE2ActionC2SPayload(int actionId, long value) implements CustomPacketPayload {
+    public static final Type<AE2ActionC2SPayload> TYPE =
+            new Type<>(ResourceLocation.fromNamespaceAndPath(AppEng.MOD_ID, "action_c2s"));
+
+    public static final StreamCodec<FriendlyByteBuf, AE2ActionC2SPayload> STREAM_CODEC = StreamCodec.of(
+            (buf, payload) -> {
+                buf.writeVarInt(payload.actionId());
+                buf.writeVarLong(payload.value());
+            },
+            buf -> new AE2ActionC2SPayload(buf.readVarInt(), buf.readVarLong()));
+
+    @Override
+    public Type<? extends CustomPacketPayload> type() {
+        return TYPE;
+    }
+}

--- a/src/main/java/appeng/core/network/payload/AE2HelloS2CPayload.java
+++ b/src/main/java/appeng/core/network/payload/AE2HelloS2CPayload.java
@@ -1,0 +1,22 @@
+package appeng.core.network.payload;
+
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceLocation;
+
+import appeng.core.AppEng;
+
+public record AE2HelloS2CPayload(String message) implements CustomPacketPayload {
+    public static final Type<AE2HelloS2CPayload> TYPE =
+            new Type<>(ResourceLocation.fromNamespaceAndPath(AppEng.MOD_ID, "hello_s2c"));
+
+    public static final StreamCodec<FriendlyByteBuf, AE2HelloS2CPayload> STREAM_CODEC = StreamCodec.of(
+            (buf, payload) -> buf.writeUtf(payload.message()),
+            buf -> new AE2HelloS2CPayload(buf.readUtf()));
+
+    @Override
+    public Type<? extends CustomPacketPayload> type() {
+        return TYPE;
+    }
+}

--- a/src/main/java/appeng/core/network/payload/AE2LoginAckC2SPayload.java
+++ b/src/main/java/appeng/core/network/payload/AE2LoginAckC2SPayload.java
@@ -1,0 +1,22 @@
+package appeng.core.network.payload;
+
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceLocation;
+
+import appeng.core.AppEng;
+
+public record AE2LoginAckC2SPayload(boolean ok) implements CustomPacketPayload {
+    public static final Type<AE2LoginAckC2SPayload> TYPE =
+            new Type<>(ResourceLocation.fromNamespaceAndPath(AppEng.MOD_ID, "login_ack_c2s"));
+
+    public static final StreamCodec<FriendlyByteBuf, AE2LoginAckC2SPayload> STREAM_CODEC = StreamCodec.of(
+            (buf, payload) -> buf.writeBoolean(payload.ok()),
+            buf -> new AE2LoginAckC2SPayload(buf.readBoolean()));
+
+    @Override
+    public Type<? extends CustomPacketPayload> type() {
+        return TYPE;
+    }
+}

--- a/src/main/java/appeng/core/network/payload/AE2LoginSyncS2CPayload.java
+++ b/src/main/java/appeng/core/network/payload/AE2LoginSyncS2CPayload.java
@@ -1,0 +1,22 @@
+package appeng.core.network.payload;
+
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceLocation;
+
+import appeng.core.AppEng;
+
+public record AE2LoginSyncS2CPayload(byte[] configBlob) implements CustomPacketPayload {
+    public static final Type<AE2LoginSyncS2CPayload> TYPE =
+            new Type<>(ResourceLocation.fromNamespaceAndPath(AppEng.MOD_ID, "login_sync_s2c"));
+
+    public static final StreamCodec<FriendlyByteBuf, AE2LoginSyncS2CPayload> STREAM_CODEC = StreamCodec.of(
+            (buf, payload) -> buf.writeByteArray(payload.configBlob()),
+            buf -> new AE2LoginSyncS2CPayload(buf.readByteArray()));
+
+    @Override
+    public Type<? extends CustomPacketPayload> type() {
+        return TYPE;
+    }
+}


### PR DESCRIPTION
## Summary
- introduce AE2Network event subscriber registering example play and login payloads
- add placeholder handlers and payload records demonstrating StreamCodec usage
- provide AE2Packets helper for sending sample messages

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68def24ed350832794152190bc255f43