### PR TITLE
Set up capability token infrastructure for grid hosts

### DIFF
--- a/src/main/java/appeng/api/AECapabilities.java
+++ b/src/main/java/appeng/api/AECapabilities.java
@@ -22,6 +22,7 @@ import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.core.Direction;
 import net.neoforged.neoforge.capabilities.BlockCapability;
+import net.neoforged.neoforge.capabilities.Capability;
 
 import appeng.api.behaviors.GenericInternalInventory;
 import appeng.api.implementations.blockentities.ICraftingMachine;
@@ -29,6 +30,7 @@ import appeng.api.implementations.blockentities.ICrankable;
 import appeng.api.networking.IInWorldGridNodeHost;
 import appeng.api.storage.MEStorage;
 import appeng.core.AppEng;
+import appeng.capability.AE2Capabilities;
 
 /**
  * Utility class that holds the capabilities provided by AE2.
@@ -51,5 +53,10 @@ public final class AECapabilities {
 
     public static BlockCapability<ICrankable, @Nullable Direction> CRANKABLE = BlockCapability
             .createSided(AppEng.makeId("crankable"), ICrankable.class);
+
+    /**
+     * NeoForge capability tokens exposed for add-ons that directly integrate with the new capability system.
+     */
+    public static final Capability<IInWorldGridNodeHost> IN_WORLD_GRID_NODE_HOST_ENTITY = AE2Capabilities.IN_WORLD_GRID_NODE_HOST;
 
 }

--- a/src/main/java/appeng/api/networking/GridHelper.java
+++ b/src/main/java/appeng/api/networking/GridHelper.java
@@ -130,7 +130,12 @@ public final class GridHelper {
      */
     @Nullable
     public static IInWorldGridNodeHost getNodeHost(Level level, BlockPos pos) {
-        return level.getCapability(AECapabilities.IN_WORLD_GRID_NODE_HOST, pos, null);
+        var blockEntity = level.getBlockEntity(pos);
+        if (blockEntity == null) {
+            return null;
+        }
+
+        return blockEntity.getCapability(AECapabilities.IN_WORLD_GRID_NODE_HOST_ENTITY, null);
     }
 
     /**

--- a/src/main/java/appeng/capability/AE2Capabilities.java
+++ b/src/main/java/appeng/capability/AE2Capabilities.java
@@ -1,0 +1,37 @@
+package appeng.capability;
+
+import net.neoforged.neoforge.capabilities.Capability;
+import net.neoforged.neoforge.capabilities.CapabilityToken;
+
+import appeng.api.behaviors.GenericInternalInventory;
+import appeng.api.implementations.blockentities.ICraftingMachine;
+import appeng.api.implementations.blockentities.ICrankable;
+import appeng.api.networking.IInWorldGridNodeHost;
+import appeng.api.storage.MEStorage;
+
+/**
+ * Central definition point for AE2 specific capabilities.
+ * <p>
+ * Capabilities are obtained through NeoForge's {@link CapabilityToken} pattern to ensure that instances are resolved
+ * lazily and stay compatible across reloads.
+ * </p>
+ */
+public final class AE2Capabilities {
+    private AE2Capabilities() {
+    }
+
+    public static final Capability<MEStorage> ME_STORAGE = new CapabilityToken<>() {
+    };
+
+    public static final Capability<ICraftingMachine> CRAFTING_MACHINE = new CapabilityToken<>() {
+    };
+
+    public static final Capability<GenericInternalInventory> GENERIC_INTERNAL_INV = new CapabilityToken<>() {
+    };
+
+    public static final Capability<IInWorldGridNodeHost> IN_WORLD_GRID_NODE_HOST = new CapabilityToken<>() {
+    };
+
+    public static final Capability<ICrankable> CRANKABLE = new CapabilityToken<>() {
+    };
+}

--- a/src/main/java/appeng/capability/AE2CapabilityAttach.java
+++ b/src/main/java/appeng/capability/AE2CapabilityAttach.java
@@ -1,0 +1,41 @@
+package appeng.capability;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.AttachCapabilitiesEvent;
+
+import appeng.capability.provider.InWorldGridNodeHostProvider;
+import appeng.api.networking.IInWorldGridNodeHost;
+import appeng.core.AppEng;
+
+@EventBusSubscriber(modid = AppEng.MOD_ID)
+public final class AE2CapabilityAttach {
+    private AE2CapabilityAttach() {
+    }
+
+    private static ResourceLocation rl(String path) {
+        return AppEng.makeId(path);
+    }
+
+    @SubscribeEvent
+    public static void onAttachBlockEntity(final AttachCapabilitiesEvent<BlockEntity> event) {
+        final BlockEntity be = event.getObject();
+        if (be instanceof IInWorldGridNodeHost host) {
+            event.addCapability(rl("inworld_gridnode_host"), new InWorldGridNodeHostProvider(be, host));
+        }
+    }
+
+    @SubscribeEvent
+    public static void onAttachItem(final AttachCapabilitiesEvent<ItemStack> event) {
+        // Intentionally left empty; item capabilities will be wired up as part of the migration.
+    }
+
+    @SubscribeEvent
+    public static void onAttachEntity(final AttachCapabilitiesEvent<Entity> event) {
+        // Intentionally left empty; entity capabilities will be wired up as part of the migration.
+    }
+}

--- a/src/main/java/appeng/capability/provider/AE2BlockEntityCapabilityProvider.java
+++ b/src/main/java/appeng/capability/provider/AE2BlockEntityCapabilityProvider.java
@@ -1,0 +1,25 @@
+package appeng.capability.provider;
+
+import java.util.Objects;
+
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.neoforged.neoforge.capabilities.Capability;
+import net.neoforged.neoforge.capabilities.ICapabilityProvider;
+
+/**
+ * Base implementation for capability providers that serve AE2 block entities.
+ */
+public abstract class AE2BlockEntityCapabilityProvider
+        implements ICapabilityProvider<BlockEntity, Direction> {
+    protected final BlockEntity be;
+
+    protected AE2BlockEntityCapabilityProvider(BlockEntity be) {
+        this.be = Objects.requireNonNull(be);
+    }
+
+    @Override
+    public <T> T getCapability(BlockEntity object, Capability<T> cap, Direction side) {
+        return null;
+    }
+}

--- a/src/main/java/appeng/capability/provider/AE2ItemCapabilityProvider.java
+++ b/src/main/java/appeng/capability/provider/AE2ItemCapabilityProvider.java
@@ -1,0 +1,15 @@
+package appeng.capability.provider;
+
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.neoforge.capabilities.Capability;
+import net.neoforged.neoforge.capabilities.ICapabilityProvider;
+
+/**
+ * Base implementation for capability providers that target AE2 item stacks.
+ */
+public abstract class AE2ItemCapabilityProvider implements ICapabilityProvider<ItemStack, Void> {
+    @Override
+    public <T> T getCapability(ItemStack stack, Capability<T> cap, Void ctx) {
+        return null;
+    }
+}

--- a/src/main/java/appeng/capability/provider/InWorldGridNodeHostProvider.java
+++ b/src/main/java/appeng/capability/provider/InWorldGridNodeHostProvider.java
@@ -1,0 +1,31 @@
+package appeng.capability.provider;
+
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.neoforged.neoforge.capabilities.Capability;
+
+import appeng.capability.AE2Capabilities;
+import appeng.api.networking.IInWorldGridNodeHost;
+
+/**
+ * Provides the {@link IInWorldGridNodeHost} capability for block entities that expose AE2 grid nodes.
+ */
+public final class InWorldGridNodeHostProvider extends AE2BlockEntityCapabilityProvider {
+    private final IInWorldGridNodeHost host;
+
+    public InWorldGridNodeHostProvider(BlockEntity be, IInWorldGridNodeHost host) {
+        super(be);
+        this.host = host;
+    }
+
+    @Override
+    public <T> T getCapability(BlockEntity object, Capability<T> cap, @Nullable Direction side) {
+        if (cap == AE2Capabilities.IN_WORLD_GRID_NODE_HOST) {
+            // The block entity manages its own lifecycle; once it is removed the grid node is detached.
+            return AE2Capabilities.IN_WORLD_GRID_NODE_HOST.cast(host);
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- define AE2 capability tokens and provider scaffolding for NeoForge
- attach the in-world grid node host capability via AttachCapabilitiesEvent
- expose a block-entity based lookup for grid hosts through the API helper

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df133c852483279074441b03b66755