### PR TITLE
Add loot modifier registrations for AE2 drops

### DIFF
--- a/src/main/java/appeng/core/AppEngBase.java
+++ b/src/main/java/appeng/core/AppEngBase.java
@@ -84,6 +84,7 @@ import appeng.server.services.ChunkLoadingService;
 import appeng.server.testworld.GameTestPlotAdapter;
 import appeng.spatial.SpatialStorageChunkGenerator;
 import appeng.spatial.SpatialStorageDimensionIds;
+import appeng.registry.AE2LootModifiers;
 import appeng.registry.AE2Registries;
 
 /**
@@ -126,6 +127,7 @@ public abstract class AppEngBase implements AppEng {
         AE2Registries.RECIPE_SERIALIZERS.register(modEventBus);
         AE2Registries.SOUNDS.register(modEventBus);
         AE2Registries.LOOT_MODIFIERS.register(modEventBus);
+        AE2LootModifiers.init();
         AEComponents.DR.register(modEventBus);
         AEEntities.DR.register(modEventBus);
         AERecipeTypes.DR.register(modEventBus);

--- a/src/main/java/appeng/data/AE2DataGen.java
+++ b/src/main/java/appeng/data/AE2DataGen.java
@@ -16,6 +16,7 @@ import appeng.data.providers.AEBlockStateProvider;
 import appeng.data.providers.AEFeatureProvider;
 import appeng.data.providers.AEItemModelProvider;
 import appeng.data.providers.AELangProvider;
+import appeng.data.providers.AELootModifierProvider;
 import appeng.data.providers.AELootTableProvider;
 import appeng.data.providers.AERecipeProvider;
 import appeng.data.providers.AETagProviders;
@@ -41,6 +42,7 @@ public final class AE2DataGen {
             generator.addProvider(true, new AETagProviders.ItemTags(packOutput, lookup, blocks));
 
             generator.addProvider(true, new AELootTableProvider(packOutput, lookup));
+            generator.addProvider(true, new AELootModifierProvider(packOutput, lookup));
 
             generator.addProvider(true, new AEFeatureProvider(packOutput, lookup));
 

--- a/src/main/java/appeng/data/providers/AELootModifierProvider.java
+++ b/src/main/java/appeng/data/providers/AELootModifierProvider.java
@@ -1,0 +1,28 @@
+package appeng.data.providers;
+
+import java.util.concurrent.CompletableFuture;
+
+import net.minecraft.core.HolderLookup;
+import net.minecraft.data.PackOutput;
+import net.minecraft.world.level.storage.loot.predicates.LootItemCondition;
+import net.minecraft.world.level.storage.loot.predicates.LootItemRandomChanceCondition;
+import net.neoforged.neoforge.common.data.GlobalLootModifierProvider;
+import net.neoforged.neoforge.common.loot.LootTableIdCondition;
+
+import appeng.core.AppEng;
+import appeng.loot.AE2CertusLootModifier;
+import appeng.loot.AE2PressLootModifier;
+
+public final class AELootModifierProvider extends GlobalLootModifierProvider {
+    public AELootModifierProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> registries) {
+        super(output, registries, AppEng.MOD_ID);
+    }
+
+    @Override
+    protected void start() {
+        add("add_presses", new AE2PressLootModifier(new LootItemCondition[] {
+                LootTableIdCondition.builder(AppEng.makeId("blocks/mysterious_cube")).build() }));
+        add("certus_extra_drops", new AE2CertusLootModifier(new LootItemCondition[] {
+                LootItemRandomChanceCondition.randomChance(0.35f).build() }));
+    }
+}

--- a/src/main/java/appeng/loot/AE2CertusLootModifier.java
+++ b/src/main/java/appeng/loot/AE2CertusLootModifier.java
@@ -1,0 +1,55 @@
+package appeng.loot;
+
+import java.util.Set;
+
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.storage.loot.LootContext;
+import net.minecraft.world.level.storage.loot.predicates.LootItemCondition;
+
+import net.neoforged.neoforge.common.loot.IGlobalLootModifier;
+import net.neoforged.neoforge.common.loot.LootModifier;
+
+import appeng.core.AppEng;
+import appeng.core.definitions.AEItems;
+
+/**
+ * Adds extra certus quartz drops for AE2 ores.
+ */
+public class AE2CertusLootModifier extends LootModifier {
+    public static final MapCodec<AE2CertusLootModifier> CODEC = RecordCodecBuilder.mapCodec(
+            instance -> codecStart(instance).apply(instance, AE2CertusLootModifier::new));
+
+    private static final Set<ResourceLocation> TARGET_LOOT_TABLES = Set.of(
+            AppEng.makeId("blocks/certus_quartz_ore"),
+            AppEng.makeId("blocks/deepslate_certus_quartz_ore"),
+            AppEng.makeId("blocks/charged_certus_quartz_ore"),
+            AppEng.makeId("blocks/charged_deepslate_certus_quartz_ore"));
+
+    protected AE2CertusLootModifier(LootItemCondition[] conditionsIn) {
+        super(conditionsIn);
+    }
+
+    @Override
+    public MapCodec<? extends IGlobalLootModifier> codec() {
+        return CODEC;
+    }
+
+    @Override
+    protected ObjectArrayList<ItemStack> doApply(ObjectArrayList<ItemStack> generatedLoot, LootContext context) {
+        if (TARGET_LOOT_TABLES.contains(context.getQueriedLootTableId())) {
+            generatedLoot.add(AEItems.CERTUS_QUARTZ_CRYSTAL.stack());
+
+            if (context.getRandom().nextFloat() < 0.15f) {
+                generatedLoot.add(AEItems.CERTUS_QUARTZ_CRYSTAL_CHARGED.stack());
+            }
+        }
+
+        return generatedLoot;
+    }
+}

--- a/src/main/java/appeng/loot/AE2PressLootModifier.java
+++ b/src/main/java/appeng/loot/AE2PressLootModifier.java
@@ -1,0 +1,74 @@
+package appeng.loot;
+
+import java.util.List;
+
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.storage.loot.LootContext;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
+import net.minecraft.world.level.storage.loot.predicates.LootItemCondition;
+
+import net.neoforged.neoforge.common.loot.IGlobalLootModifier;
+import net.neoforged.neoforge.common.loot.LootModifier;
+
+import appeng.core.AEConfig;
+import appeng.core.AppEng;
+import appeng.core.definitions.AEBlocks;
+import appeng.core.definitions.AEItems;
+
+/**
+ * Injects inscriber presses into mysterious cube drops using NeoForge's loot modifier system.
+ */
+public class AE2PressLootModifier extends LootModifier {
+    public static final MapCodec<AE2PressLootModifier> CODEC = RecordCodecBuilder.mapCodec(
+            instance -> codecStart(instance).apply(instance, AE2PressLootModifier::new));
+
+    private static final List<ItemStack> PRESS_LOOT = List.of(
+            AEItems.LOGIC_PROCESSOR_PRESS.stack(),
+            AEItems.CALCULATION_PROCESSOR_PRESS.stack(),
+            AEItems.ENGINEERING_PROCESSOR_PRESS.stack(),
+            AEItems.SILICON_PRESS.stack(),
+            AEItems.NAME_PRESS.stack());
+
+    private static final ResourceLocation MYSTERIOUS_CUBE_LOOT = AppEng.makeId("blocks/mysterious_cube");
+
+    protected AE2PressLootModifier(LootItemCondition[] conditionsIn) {
+        super(conditionsIn);
+    }
+
+    @Override
+    public MapCodec<? extends IGlobalLootModifier> codec() {
+        return CODEC;
+    }
+
+    @Override
+    protected ObjectArrayList<ItemStack> doApply(ObjectArrayList<ItemStack> generatedLoot, LootContext context) {
+        if (!AEConfig.instance().isSpawnPressesInMeteoritesEnabled()) {
+            return generatedLoot;
+        }
+
+        var blockState = context.getParamOrNull(LootContextParams.BLOCK_STATE);
+        if (blockState != null && blockState.getBlock() == AEBlocks.MYSTERIOUS_CUBE.block()) {
+            addPressDrop(generatedLoot, context);
+            return generatedLoot;
+        }
+
+        var lootTableId = context.getQueriedLootTableId();
+        if (MYSTERIOUS_CUBE_LOOT.equals(lootTableId)) {
+            addPressDrop(generatedLoot, context);
+        }
+
+        return generatedLoot;
+    }
+
+    private static void addPressDrop(ObjectArrayList<ItemStack> generatedLoot, LootContext context) {
+        var random = context.getRandom();
+        var press = PRESS_LOOT.get(random.nextInt(PRESS_LOOT.size())).copy();
+        generatedLoot.add(press);
+    }
+}

--- a/src/main/java/appeng/registry/AE2LootModifiers.java
+++ b/src/main/java/appeng/registry/AE2LootModifiers.java
@@ -1,0 +1,24 @@
+package appeng.registry;
+
+import com.mojang.serialization.Codec;
+
+import net.neoforged.neoforge.common.loot.IGlobalLootModifier;
+import net.neoforged.neoforge.registries.RegistryObject;
+
+import appeng.loot.AE2CertusLootModifier;
+import appeng.loot.AE2PressLootModifier;
+
+public final class AE2LootModifiers {
+    private AE2LootModifiers() {
+    }
+
+    public static final RegistryObject<Codec<? extends IGlobalLootModifier>> PRESS_LOOT =
+            AE2Registries.LOOT_MODIFIERS.register("add_presses", () -> AE2PressLootModifier.CODEC.codec());
+
+    public static final RegistryObject<Codec<? extends IGlobalLootModifier>> CERTUS_EXTRA_DROPS =
+            AE2Registries.LOOT_MODIFIERS.register("certus_extra_drops", () -> AE2CertusLootModifier.CODEC.codec());
+
+    public static void init() {
+        // Intentionally empty to force the class to load and register modifiers.
+    }
+}

--- a/src/main/resources/data/ae2/loot_modifiers/add_presses.json
+++ b/src/main/resources/data/ae2/loot_modifiers/add_presses.json
@@ -1,0 +1,9 @@
+{
+  "type": "ae2:add_presses",
+  "conditions": [
+    {
+      "condition": "neoforge:loot_table_id",
+      "loot_table_id": "ae2:blocks/mysterious_cube"
+    }
+  ]
+}

--- a/src/main/resources/data/ae2/loot_modifiers/certus_extra_drops.json
+++ b/src/main/resources/data/ae2/loot_modifiers/certus_extra_drops.json
@@ -1,0 +1,9 @@
+{
+  "type": "ae2:certus_extra_drops",
+  "conditions": [
+    {
+      "condition": "minecraft:random_chance",
+      "chance": 0.35
+    }
+  ]
+}

--- a/src/main/resources/data/neoforge/loot_modifiers/global_loot_modifiers.json
+++ b/src/main/resources/data/neoforge/loot_modifiers/global_loot_modifiers.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "entries": [
+    "ae2:add_presses",
+    "ae2:certus_extra_drops"
+  ]
+}


### PR DESCRIPTION
## Summary
- implement NeoForge global loot modifiers for meteorite presses and certus quartz ore bonuses
- register the codecs through AE2Registries and expose a data provider for modifier JSON
- seed the datapack resources for the new modifiers and include them in the global loot modifier list

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68df363ed6b88327be5254123f66a9cb