### PR TITLE
Add interop scaffolding for JEI, REI, and Curios

### DIFF
--- a/src/main/java/appeng/api/AECapabilities.java
+++ b/src/main/java/appeng/api/AECapabilities.java
@@ -57,6 +57,14 @@ public final class AECapabilities {
     /**
      * NeoForge capability tokens exposed for add-ons that directly integrate with the new capability system.
      */
+    public static final Capability<MEStorage> ME_STORAGE_ENTITY = AE2Capabilities.ME_STORAGE;
+
+    public static final Capability<ICraftingMachine> CRAFTING_MACHINE_ENTITY = AE2Capabilities.CRAFTING_MACHINE;
+
+    public static final Capability<GenericInternalInventory> GENERIC_INTERNAL_INV_ENTITY = AE2Capabilities.GENERIC_INTERNAL_INV;
+
     public static final Capability<IInWorldGridNodeHost> IN_WORLD_GRID_NODE_HOST_ENTITY = AE2Capabilities.IN_WORLD_GRID_NODE_HOST;
+
+    public static final Capability<ICrankable> CRANKABLE_ENTITY = AE2Capabilities.CRANKABLE;
 
 }

--- a/src/main/java/appeng/api/compat/CuriosCompat.java
+++ b/src/main/java/appeng/api/compat/CuriosCompat.java
@@ -1,0 +1,53 @@
+package appeng.api.compat;
+
+import java.util.Optional;
+
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.world.entity.player.Player;
+import net.neoforged.fml.ModList;
+import net.neoforged.neoforge.capabilities.EntityCapability;
+import net.neoforged.neoforge.items.IItemHandler;
+
+import appeng.core.AE2InteropValidator;
+import appeng.integration.modules.curios.CuriosIntegration;
+
+/**
+ * Helper for interacting with Curios without forcing a hard dependency.
+ */
+public final class CuriosCompat {
+    public static final String MOD_ID = "curios";
+
+    private CuriosCompat() {
+    }
+
+    public static boolean isLoaded() {
+        return ModList.get().isLoaded(MOD_ID);
+    }
+
+    public static Optional<IItemHandler> getCuriosHandler(Player player) {
+        if (!isLoaded()) {
+            return Optional.empty();
+        }
+
+        return Optional.ofNullable(player.getCapability(CuriosIntegration.ITEM_HANDLER));
+    }
+
+    public static Optional<IItemHandler> getCuriosHandler(@Nullable Player player, int slot) {
+        if (player == null) {
+            return Optional.empty();
+        }
+
+        return getCuriosHandler(player).filter(handler -> slot >= 0 && slot < handler.getSlots());
+    }
+
+    public static EntityCapability<IItemHandler, Void> capability() {
+        return CuriosIntegration.ITEM_HANDLER;
+    }
+
+    public static void reportBridgeInitialized() {
+        if (isLoaded()) {
+            AE2InteropValidator.markBridgeInitialized("Curios capability bridge");
+        }
+    }
+}

--- a/src/main/java/appeng/api/compat/JeiCompat.java
+++ b/src/main/java/appeng/api/compat/JeiCompat.java
@@ -1,0 +1,22 @@
+package appeng.api.compat;
+
+import net.neoforged.fml.ModList;
+
+import appeng.core.AE2InteropValidator;
+
+public final class JeiCompat {
+    public static final String MOD_ID = "jei";
+
+    private JeiCompat() {
+    }
+
+    public static boolean isLoaded() {
+        return ModList.get().isLoaded(MOD_ID);
+    }
+
+    public static void reportBridgeInitialized() {
+        if (isLoaded()) {
+            AE2InteropValidator.markBridgeInitialized("JEI plugin bridge");
+        }
+    }
+}

--- a/src/main/java/appeng/api/compat/ReiCompat.java
+++ b/src/main/java/appeng/api/compat/ReiCompat.java
@@ -1,0 +1,22 @@
+package appeng.api.compat;
+
+import net.neoforged.fml.ModList;
+
+import appeng.core.AE2InteropValidator;
+
+public final class ReiCompat {
+    public static final String MOD_ID = "roughlyenoughitems";
+
+    private ReiCompat() {
+    }
+
+    public static boolean isLoaded() {
+        return ModList.get().isLoaded(MOD_ID) || ModList.get().isLoaded("rei");
+    }
+
+    public static void reportBridgeInitialized() {
+        if (isLoaded()) {
+            AE2InteropValidator.markBridgeInitialized("REI client bridge");
+        }
+    }
+}

--- a/src/main/java/appeng/api/networking/interop/GridApi.java
+++ b/src/main/java/appeng/api/networking/interop/GridApi.java
@@ -1,0 +1,42 @@
+package appeng.api.networking.interop;
+
+import java.util.Optional;
+
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+
+import appeng.api.AECapabilities;
+import appeng.api.networking.GridHelper;
+import appeng.api.networking.IGridNode;
+import appeng.api.networking.IInWorldGridNodeHost;
+import appeng.core.AE2InteropValidator;
+
+/**
+ * Entry point for add-ons that want to interact with AE2 grid hosts without touching internal helpers.
+ */
+public final class GridApi {
+    public static final GridApi INSTANCE = new GridApi();
+
+    private GridApi() {
+        AE2InteropValidator.markBridgeInitialized("Grid capability helpers");
+    }
+
+    public Optional<IInWorldGridNodeHost> findNodeHost(Level level, BlockPos pos) {
+        return Optional.ofNullable(GridHelper.getNodeHost(level, pos));
+    }
+
+    public Optional<IGridNode> findExposedNode(Level level, BlockPos pos, Direction side) {
+        return Optional.ofNullable(GridHelper.getExposedNode(level, pos, side));
+    }
+
+    public Optional<IInWorldGridNodeHost> findNodeHost(Level level, BlockPos pos, @Nullable BlockEntity blockEntity) {
+        if (blockEntity != null && blockEntity.getLevel() == level) {
+            return Optional.ofNullable(blockEntity.getCapability(AECapabilities.IN_WORLD_GRID_NODE_HOST_ENTITY, null));
+        }
+        return findNodeHost(level, pos);
+    }
+}

--- a/src/main/java/appeng/api/storage/StorageApi.java
+++ b/src/main/java/appeng/api/storage/StorageApi.java
@@ -1,0 +1,43 @@
+package appeng.api.storage;
+
+import java.util.Optional;
+
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+
+import appeng.api.AECapabilities;
+import appeng.api.storage.MEStorage;
+import appeng.core.AE2InteropValidator;
+
+/**
+ * Public helpers for looking up ME storage providers exposed through the capability system.
+ */
+public final class StorageApi {
+    public static final StorageApi INSTANCE = new StorageApi();
+
+    private StorageApi() {
+        AE2InteropValidator.markBridgeInitialized("ME storage helpers");
+    }
+
+    public Optional<MEStorage> findStorage(Level level, BlockPos pos, @Nullable Direction side) {
+        var blockEntity = level.getBlockEntity(pos);
+        if (blockEntity == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(level.getCapability(AECapabilities.ME_STORAGE, pos,
+                blockEntity.getBlockState(), blockEntity, side));
+    }
+
+    public Optional<MEStorage> findStorage(BlockEntity blockEntity, @Nullable Direction side) {
+        if (blockEntity == null || blockEntity.getLevel() == null) {
+            return Optional.empty();
+        }
+        var level = blockEntity.getLevel();
+        return Optional.ofNullable(level.getCapability(AECapabilities.ME_STORAGE, blockEntity.getBlockPos(),
+                blockEntity.getBlockState(), blockEntity, side));
+    }
+}

--- a/src/main/java/appeng/client/jei/AE2JeiPlugin.java
+++ b/src/main/java/appeng/client/jei/AE2JeiPlugin.java
@@ -1,0 +1,82 @@
+package appeng.client.jei;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.item.crafting.RecipeHolder;
+
+import mezz.jei.api.IModPlugin;
+import mezz.jei.api.JeiPlugin;
+import mezz.jei.api.helpers.IGuiHelper;
+import mezz.jei.api.recipe.RecipeType;
+import mezz.jei.api.registration.IRecipeCatalystRegistration;
+import mezz.jei.api.registration.IRecipeCategoryRegistration;
+import mezz.jei.api.registration.IRecipeRegistration;
+
+import appeng.api.compat.JeiCompat;
+import appeng.core.AppEng;
+import appeng.core.definitions.AEBlocks;
+import appeng.core.definitions.AEItems;
+import appeng.recipes.handlers.ChargerRecipe;
+import appeng.recipes.handlers.InscriberRecipe;
+import appeng.recipes.quartzcutting.QuartzCuttingRecipe;
+import appeng.registry.AE2RecipeTypes;
+
+@JeiPlugin
+public final class AE2JeiPlugin implements IModPlugin {
+    static final ResourceLocation TEXTURE = AppEng.makeId("textures/guis/jei.png");
+
+    public static final RecipeType<InscriberRecipe> INSCRIBER = new RecipeType<>(
+            Objects.requireNonNull(AE2RecipeTypes.INSCRIBER.getId()), InscriberRecipe.class);
+    public static final RecipeType<ChargerRecipe> CHARGER = new RecipeType<>(
+            Objects.requireNonNull(AE2RecipeTypes.CHARGER.getId()), ChargerRecipe.class);
+    public static final RecipeType<QuartzCuttingRecipe> QUARTZ_CUTTING = new RecipeType<>(
+            Objects.requireNonNull(AE2RecipeTypes.QUARTZ_CUTTING.getId()), QuartzCuttingRecipe.class);
+
+    private static final ResourceLocation ID = AppEng.makeId("jei_plugin");
+
+    @Override
+    public ResourceLocation getPluginUid() {
+        return ID;
+    }
+
+    @Override
+    public void registerCategories(IRecipeCategoryRegistration registration) {
+        IGuiHelper guiHelper = registration.getJeiHelpers().getGuiHelper();
+        registration.addRecipeCategories(
+                new InscriberCategory(guiHelper),
+                new ChargerCategory(guiHelper),
+                new QuartzCuttingCategory(guiHelper));
+        JeiCompat.reportBridgeInitialized();
+    }
+
+    @Override
+    public void registerRecipes(IRecipeRegistration registration) {
+        registration.addRecipes(INSCRIBER, unwrap(findRecipes(AE2RecipeTypes.INSCRIBER.get())));
+        registration.addRecipes(CHARGER, unwrap(findRecipes(AE2RecipeTypes.CHARGER.get())));
+        registration.addRecipes(QUARTZ_CUTTING, unwrap(findRecipes(AE2RecipeTypes.QUARTZ_CUTTING.get())));
+    }
+
+    @Override
+    public void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
+        registration.addRecipeCatalyst(AEBlocks.INSCRIBER.stack(), INSCRIBER);
+        registration.addRecipeCatalyst(AEBlocks.CHARGER.stack(), CHARGER);
+        registration.addRecipeCatalyst(AEItems.CERTUS_QUARTZ_DUST.stack(), QUARTZ_CUTTING);
+    }
+
+    private static <T extends Recipe<?>> List<T> unwrap(Collection<RecipeHolder<T>> recipes) {
+        return recipes.stream().map(RecipeHolder::value).toList();
+    }
+
+    private static <T extends Recipe<?>> Collection<RecipeHolder<T>> findRecipes(net.minecraft.world.item.crafting.RecipeType<T> type) {
+        var level = Minecraft.getInstance().level;
+        if (level == null) {
+            return List.of();
+        }
+        return level.getRecipeManager().getAllRecipesFor(type);
+    }
+}

--- a/src/main/java/appeng/client/jei/ChargerCategory.java
+++ b/src/main/java/appeng/client/jei/ChargerCategory.java
@@ -1,0 +1,52 @@
+package appeng.client.jei;
+
+import net.minecraft.network.chat.Component;
+
+import mezz.jei.api.constants.VanillaTypes;
+import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
+import mezz.jei.api.gui.drawable.IDrawable;
+import mezz.jei.api.helpers.IGuiHelper;
+import mezz.jei.api.recipe.IFocusGroup;
+import mezz.jei.api.recipe.RecipeIngredientRole;
+import mezz.jei.api.recipe.category.IRecipeCategory;
+
+import appeng.core.definitions.AEBlocks;
+import appeng.recipes.handlers.ChargerRecipe;
+
+final class ChargerCategory implements IRecipeCategory<ChargerRecipe> {
+    private final IDrawable background;
+    private final IDrawable icon;
+
+    ChargerCategory(IGuiHelper guiHelper) {
+        this.background = guiHelper.createDrawable(AE2JeiPlugin.TEXTURE, 0, 60, 150, 60);
+        this.icon = guiHelper.createDrawableIngredient(VanillaTypes.ITEM_STACK, AEBlocks.CHARGER.stack());
+    }
+
+    @Override
+    public mezz.jei.api.recipe.RecipeType<ChargerRecipe> getRecipeType() {
+        return AE2JeiPlugin.CHARGER;
+    }
+
+    @Override
+    public Component getTitle() {
+        return Component.translatable("gui.ae2.jei.charger");
+    }
+
+    @Override
+    public IDrawable getBackground() {
+        return background;
+    }
+
+    @Override
+    public IDrawable getIcon() {
+        return icon;
+    }
+
+    @Override
+    public void setRecipe(IRecipeLayoutBuilder builder, ChargerRecipe recipe, IFocusGroup focuses) {
+        builder.addSlot(RecipeIngredientRole.INPUT, 44, 24)
+                .addIngredients(recipe.getIngredient());
+        builder.addSlot(RecipeIngredientRole.OUTPUT, 98, 24)
+                .addItemStack(recipe.getResultItem());
+    }
+}

--- a/src/main/java/appeng/client/jei/InscriberCategory.java
+++ b/src/main/java/appeng/client/jei/InscriberCategory.java
@@ -1,0 +1,56 @@
+package appeng.client.jei;
+
+import net.minecraft.network.chat.Component;
+
+import mezz.jei.api.constants.VanillaTypes;
+import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
+import mezz.jei.api.gui.drawable.IDrawable;
+import mezz.jei.api.helpers.IGuiHelper;
+import mezz.jei.api.recipe.IFocusGroup;
+import mezz.jei.api.recipe.RecipeIngredientRole;
+import mezz.jei.api.recipe.category.IRecipeCategory;
+
+import appeng.core.definitions.AEBlocks;
+import appeng.recipes.handlers.InscriberRecipe;
+
+final class InscriberCategory implements IRecipeCategory<InscriberRecipe> {
+    private final IDrawable background;
+    private final IDrawable icon;
+
+    InscriberCategory(IGuiHelper guiHelper) {
+        this.background = guiHelper.createDrawable(AE2JeiPlugin.TEXTURE, 0, 0, 150, 60);
+        this.icon = guiHelper.createDrawableIngredient(VanillaTypes.ITEM_STACK, AEBlocks.INSCRIBER.stack());
+    }
+
+    @Override
+    public mezz.jei.api.recipe.RecipeType<InscriberRecipe> getRecipeType() {
+        return AE2JeiPlugin.INSCRIBER;
+    }
+
+    @Override
+    public Component getTitle() {
+        return Component.translatable("gui.ae2.jei.inscriber");
+    }
+
+    @Override
+    public IDrawable getBackground() {
+        return background;
+    }
+
+    @Override
+    public IDrawable getIcon() {
+        return icon;
+    }
+
+    @Override
+    public void setRecipe(IRecipeLayoutBuilder builder, InscriberRecipe recipe, IFocusGroup focuses) {
+        builder.addSlot(RecipeIngredientRole.INPUT, 20, 6)
+                .addIngredients(recipe.getTopOptional());
+        builder.addSlot(RecipeIngredientRole.INPUT, 62, 24)
+                .addIngredients(recipe.getMiddleInput());
+        builder.addSlot(RecipeIngredientRole.INPUT, 20, 42)
+                .addIngredients(recipe.getBottomOptional());
+        builder.addSlot(RecipeIngredientRole.OUTPUT, 110, 24)
+                .addItemStack(recipe.getResultItem());
+    }
+}

--- a/src/main/java/appeng/client/jei/QuartzCuttingCategory.java
+++ b/src/main/java/appeng/client/jei/QuartzCuttingCategory.java
@@ -1,0 +1,72 @@
+package appeng.client.jei;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.level.Level;
+
+import mezz.jei.api.constants.VanillaTypes;
+import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
+import mezz.jei.api.gui.drawable.IDrawable;
+import mezz.jei.api.helpers.IGuiHelper;
+import mezz.jei.api.recipe.IFocusGroup;
+import mezz.jei.api.recipe.RecipeIngredientRole;
+import mezz.jei.api.recipe.category.IRecipeCategory;
+
+import appeng.core.definitions.AEItems;
+import appeng.recipes.quartzcutting.QuartzCuttingRecipe;
+
+final class QuartzCuttingCategory implements IRecipeCategory<QuartzCuttingRecipe> {
+    private final IDrawable background;
+    private final IDrawable icon;
+
+    QuartzCuttingCategory(IGuiHelper guiHelper) {
+        this.background = guiHelper.createDrawable(AE2JeiPlugin.TEXTURE, 0, 120, 150, 60);
+        this.icon = guiHelper.createDrawableIngredient(VanillaTypes.ITEM_STACK, AEItems.CERTUS_QUARTZ_DUST.stack());
+    }
+
+    @Override
+    public mezz.jei.api.recipe.RecipeType<QuartzCuttingRecipe> getRecipeType() {
+        return AE2JeiPlugin.QUARTZ_CUTTING;
+    }
+
+    @Override
+    public Component getTitle() {
+        return Component.translatable("gui.ae2.jei.quartz_cutting");
+    }
+
+    @Override
+    public IDrawable getBackground() {
+        return background;
+    }
+
+    @Override
+    public IDrawable getIcon() {
+        return icon;
+    }
+
+    @Override
+    public void setRecipe(IRecipeLayoutBuilder builder, QuartzCuttingRecipe recipe, IFocusGroup focuses) {
+        var ingredients = recipe.getIngredients();
+        int baseX = 16;
+        int baseY = 6;
+        for (int i = 0; i < ingredients.size(); i++) {
+            int x = baseX + (i % 3) * 18;
+            int y = baseY + (i / 3) * 18;
+            builder.addSlot(RecipeIngredientRole.INPUT, x, y)
+                    .addIngredients(ingredients.get(i));
+        }
+
+        builder.addSlot(RecipeIngredientRole.OUTPUT, 120, 24)
+                .addItemStack(recipe.getResultItem(registryAccess()));
+    }
+
+    private static net.minecraft.core.HolderLookup.Provider registryAccess() {
+        var minecraft = Minecraft.getInstance();
+        Level level = minecraft.level;
+        if (level != null) {
+            return level.registryAccess();
+        }
+        var connection = minecraft.getConnection();
+        return connection != null ? connection.registryAccess() : null;
+    }
+}

--- a/src/main/java/appeng/client/rei/AE2ReiPlugin.java
+++ b/src/main/java/appeng/client/rei/AE2ReiPlugin.java
@@ -1,0 +1,30 @@
+package appeng.client.rei;
+
+import me.shedaniel.rei.api.client.registry.category.CategoryRegistry;
+import me.shedaniel.rei.api.client.registry.display.DisplayRegistry;
+import me.shedaniel.rei.api.client.registry.transfer.TransferHandlerRegistry;
+import me.shedaniel.rei.forge.REIPluginClient;
+
+import appeng.api.compat.ReiCompat;
+import appeng.integration.modules.rei.ReiPlugin;
+
+@REIPluginClient
+public final class AE2ReiPlugin extends ReiPlugin {
+    @Override
+    public void registerCategories(CategoryRegistry registry) {
+        super.registerCategories(registry);
+        ReiCompat.reportBridgeInitialized();
+    }
+
+    @Override
+    public void registerDisplays(DisplayRegistry registry) {
+        super.registerDisplays(registry);
+        ReiCompat.reportBridgeInitialized();
+    }
+
+    @Override
+    public void registerTransferHandlers(TransferHandlerRegistry registry) {
+        super.registerTransferHandlers(registry);
+        ReiCompat.reportBridgeInitialized();
+    }
+}

--- a/src/main/java/appeng/core/AE2InteropValidator.java
+++ b/src/main/java/appeng/core/AE2InteropValidator.java
@@ -1,0 +1,96 @@
+package appeng.core;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import net.neoforged.neoforge.capabilities.Capability;
+
+import appeng.api.AECapabilities;
+import appeng.api.compat.CuriosCompat;
+import appeng.api.compat.JeiCompat;
+import appeng.api.compat.ReiCompat;
+import appeng.api.networking.interop.GridApi;
+import appeng.api.storage.StorageApi;
+import appeng.capability.AE2Capabilities;
+
+/**
+ * Logs the status of optional integrations and exposed API entry points during startup.
+ */
+public final class AE2InteropValidator {
+    private static final Set<String> REGISTERED_BRIDGES = ConcurrentHashMap.newKeySet();
+
+    private AE2InteropValidator() {
+    }
+
+    public static void markBridgeInitialized(String name) {
+        REGISTERED_BRIDGES.add(name);
+        AELog.info("[Interop] Bridge initialized: %s", name);
+    }
+
+    public static void logStatus() {
+        AELog.info("[Interop] Optional mod detection: %s", discoverOptionalMods());
+        AELog.info("[Interop] API bridges registered: %s", registeredBridges());
+        AELog.info("[Interop] Capability tokens: %s", listCapabilityTokens());
+        AELog.info("[Interop] Block capabilities: %s", listBlockCapabilities());
+
+        // Touch helpers to ensure they are not stripped and to hint at availability in logs.
+        AELog.info("[Interop] Grid API helper ready: %s", GridApi.INSTANCE.getClass().getSimpleName());
+        AELog.info("[Interop] Storage API helper ready: %s", StorageApi.INSTANCE.getClass().getSimpleName());
+    }
+
+    private static String discoverOptionalMods() {
+        Map<String, Boolean> detection = new LinkedHashMap<>();
+        detection.put("JEI", JeiCompat.isLoaded());
+        detection.put("REI", ReiCompat.isLoaded());
+        detection.put("Curios", CuriosCompat.isLoaded());
+        return detection.entrySet().stream()
+                .map(entry -> entry.getKey() + '=' + (entry.getValue() ? "present" : "absent"))
+                .collect(Collectors.joining(", "));
+    }
+
+    private static String registeredBridges() {
+        if (REGISTERED_BRIDGES.isEmpty()) {
+            return "none";
+        }
+        return REGISTERED_BRIDGES.stream().sorted().collect(Collectors.joining(", "));
+    }
+
+    private static String listCapabilityTokens() {
+        List<String> tokens = new ArrayList<>();
+        for (Field field : AE2Capabilities.class.getDeclaredFields()) {
+            if (!Modifier.isStatic(field.getModifiers())) {
+                continue;
+            }
+            if (!Capability.class.isAssignableFrom(field.getType())) {
+                continue;
+            }
+            tokens.add(field.getName());
+        }
+
+        Collections.sort(tokens);
+        return String.join(", ", tokens);
+    }
+
+    private static String listBlockCapabilities() {
+        List<String> tokens = new ArrayList<>();
+        for (Field field : AECapabilities.class.getDeclaredFields()) {
+            if (!Modifier.isStatic(field.getModifiers())) {
+                continue;
+            }
+            if (!field.getType().getSimpleName().contains("Capability")) {
+                continue;
+            }
+            tokens.add(field.getName());
+        }
+        Collections.sort(tokens);
+        return String.join(", ", tokens);
+    }
+}

--- a/src/main/java/appeng/core/AppEngBase.java
+++ b/src/main/java/appeng/core/AppEngBase.java
@@ -59,6 +59,7 @@ import appeng.core.definitions.AEItems;
 import appeng.core.definitions.AEParts;
 import appeng.core.network.ClientboundPacket;
 import appeng.core.network.InitNetwork;
+import appeng.core.AE2InteropValidator;
 import appeng.hooks.SkyStoneBreakSpeed;
 import appeng.hooks.WrenchHook;
 import appeng.hooks.ticking.TickHandler;
@@ -210,6 +211,8 @@ public abstract class AppEngBase implements AppEng {
         InitDispenserBehavior.init();
 
         InitUpgrades.init();
+
+        AE2InteropValidator.logStatus();
     }
 
     public void registerKeyTypes(Registry<AEKeyType> registry) {

--- a/src/main/java/appeng/hotkeys/CuriosHotkeyAction.java
+++ b/src/main/java/appeng/hotkeys/CuriosHotkeyAction.java
@@ -6,8 +6,8 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.ItemLike;
 
+import appeng.api.compat.CuriosCompat;
 import appeng.api.features.HotkeyAction;
-import appeng.integration.modules.curios.CuriosIntegration;
 import appeng.menu.locator.MenuLocators;
 
 public record CuriosHotkeyAction(Predicate<ItemStack> locatable,
@@ -19,9 +19,12 @@ public record CuriosHotkeyAction(Predicate<ItemStack> locatable,
 
     @Override
     public boolean run(Player player) {
-        var cap = player.getCapability(CuriosIntegration.ITEM_HANDLER);
-        if (cap == null)
+        var handler = CuriosCompat.getCuriosHandler(player);
+        if (handler.isEmpty()) {
             return false;
+        }
+
+        var cap = handler.orElseThrow();
         for (int i = 0; i < cap.getSlots(); i++) {
             if (locatable.test(cap.getStackInSlot(i))) {
                 if (opener.open(player, MenuLocators.forCurioSlot(i))) {

--- a/src/main/java/appeng/hotkeys/HotkeyActions.java
+++ b/src/main/java/appeng/hotkeys/HotkeyActions.java
@@ -11,6 +11,7 @@ import java.util.Map;
 
 import net.minecraft.world.level.ItemLike;
 
+import appeng.api.compat.CuriosCompat;
 import appeng.api.features.HotkeyAction;
 import appeng.core.AppEng;
 import appeng.core.definitions.AEItems;
@@ -56,7 +57,10 @@ public class HotkeyActions {
      */
     public static void register(ItemLike item, InventoryHotkeyAction.Opener opener, String id) {
         register(new InventoryHotkeyAction(item, opener), id);
-        register(new CuriosHotkeyAction(item, opener), id);
+        if (CuriosCompat.isLoaded()) {
+            CuriosCompat.reportBridgeInitialized();
+            register(new CuriosHotkeyAction(item, opener), id);
+        }
     }
 
     /**

--- a/src/main/java/appeng/integration/compat/InteropBootstrap.java
+++ b/src/main/java/appeng/integration/compat/InteropBootstrap.java
@@ -1,0 +1,48 @@
+package appeng.integration.compat;
+
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.Mod;
+import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
+import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
+
+import appeng.api.compat.CuriosCompat;
+import appeng.api.compat.JeiCompat;
+import appeng.api.compat.ReiCompat;
+import appeng.api.ids.AEConstants;
+
+@Mod.EventBusSubscriber(modid = AEConstants.MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
+public final class InteropBootstrap {
+    private InteropBootstrap() {
+    }
+
+    @SubscribeEvent
+    public static void onClientSetup(FMLClientSetupEvent event) {
+        event.enqueueWork(() -> {
+            if (JeiCompat.isLoaded()) {
+                JeiCompat.reportBridgeInitialized();
+            }
+            if (ReiCompat.isLoaded()) {
+                ReiCompat.reportBridgeInitialized();
+            }
+            if (CuriosCompat.isLoaded()) {
+                CuriosCompat.reportBridgeInitialized();
+            }
+        });
+    }
+
+    @Mod.EventBusSubscriber(modid = AEConstants.MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD)
+    public static final class Common {
+        private Common() {
+        }
+
+        @SubscribeEvent
+        public static void onCommonSetup(FMLCommonSetupEvent event) {
+            event.enqueueWork(() -> {
+                if (CuriosCompat.isLoaded()) {
+                    CuriosCompat.reportBridgeInitialized();
+                }
+            });
+        }
+    }
+}

--- a/src/main/java/appeng/integration/modules/rei/ReiPlugin.java
+++ b/src/main/java/appeng/integration/modules/rei/ReiPlugin.java
@@ -48,7 +48,6 @@ import me.shedaniel.rei.api.common.entry.EntryStack;
 import me.shedaniel.rei.api.common.entry.type.VanillaEntryTypes;
 import me.shedaniel.rei.api.common.util.EntryIngredients;
 import me.shedaniel.rei.api.common.util.EntryStacks;
-import me.shedaniel.rei.forge.REIPluginClient;
 import me.shedaniel.rei.plugin.common.BuiltinPlugin;
 import me.shedaniel.rei.plugin.common.displays.DefaultInformationDisplay;
 import me.shedaniel.rei.plugin.common.displays.crafting.DefaultCustomShapelessDisplay;
@@ -84,7 +83,6 @@ import appeng.recipes.handlers.ChargerRecipe;
 import appeng.recipes.handlers.InscriberRecipe;
 import appeng.recipes.transform.TransformRecipe;
 
-@REIPluginClient
 public class ReiPlugin implements REIClientPlugin {
     static final ResourceLocation TEXTURE = AppEng.makeId("textures/guis/jei.png");
 

--- a/src/main/java/appeng/menu/locator/CuriosItemLocator.java
+++ b/src/main/java/appeng/menu/locator/CuriosItemLocator.java
@@ -9,18 +9,18 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.phys.BlockHitResult;
 
-import appeng.integration.modules.curios.CuriosIntegration;
+import appeng.api.compat.CuriosCompat;
 
 /**
  * Implements {@link ItemMenuHostLocator} for items equipped in curios slots.
  */
 record CuriosItemLocator(int curioSlot, @Nullable BlockHitResult hitResult) implements ItemMenuHostLocator {
     public ItemStack locateItem(Player player) {
-        var cap = player.getCapability(CuriosIntegration.ITEM_HANDLER);
-        if (cap == null || curioSlot >= cap.getSlots()) {
+        var handler = CuriosCompat.getCuriosHandler(player, curioSlot);
+        if (handler.isEmpty()) {
             return ItemStack.EMPTY;
         }
-        return cap.getStackInSlot(curioSlot);
+        return handler.orElseThrow().getStackInSlot(curioSlot);
     }
 
     public void writeToPacket(FriendlyByteBuf buf) {

--- a/src/main/java/appeng/util/SearchInventoryEvent.java
+++ b/src/main/java/appeng/util/SearchInventoryEvent.java
@@ -8,7 +8,7 @@ import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 
-import appeng.integration.modules.curios.CuriosIntegration;
+import appeng.api.compat.CuriosCompat;
 
 /**
  * Event fired when AE2 is looking for ItemStacks in a player inventory. By default, AE2 only looks at the 36 usual
@@ -31,14 +31,12 @@ public class SearchInventoryEvent extends PlayerEvent {
         NeoForge.EVENT_BUS.addListener((SearchInventoryEvent event) -> {
             event.getStacks().addAll(event.getEntity().getInventory().items);
         });
-        NeoForge.EVENT_BUS.addListener((SearchInventoryEvent event) -> {
-            var cap = event.getEntity().getCapability(CuriosIntegration.ITEM_HANDLER);
-            if (cap == null)
-                return;
-            for (int i = 0; i < cap.getSlots(); i++) {
-                event.getStacks().add(cap.getStackInSlot(i));
-            }
-        });
+        NeoForge.EVENT_BUS.addListener((SearchInventoryEvent event) -> CuriosCompat.getCuriosHandler(event.getEntity())
+                .ifPresent(handler -> {
+                    for (int i = 0; i < handler.getSlots(); i++) {
+                        event.getStacks().add(handler.getStackInSlot(i));
+                    }
+                }));
     }
 
     public static List<ItemStack> getItems(Player player) {


### PR DESCRIPTION
## Summary
- add a JEI plugin under the client package with stubbed recipe categories for inscriber, charger, and quartz cutting layouts
- wrap the existing REI plugin with a client entrypoint while exposing optional mod helpers and integration bootstrap logging
- surface new API helpers for capabilities, grid/storage lookup, and log optional mod detection while guarding Curios usage when absent

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e061d0d3788327b25caa485cd99b1c