### PR TITLE
Add guarded CI workflow and documentation scaffolding

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -33,9 +33,16 @@ Please note that we might close any issue not matching these requirements.
   * This `master` branch that is under active development.
   * Only target release branches if you are certain your fix must be on that
     branch.
-  * To quickly create a topic branch based on the development branch; `git 
-    checkout -b my_contribution_branch`. Please avoid working 
+  * To quickly create a topic branch based on the development branch; `git
+    checkout -b my_contribution_branch`. Please avoid working
     directly on the `master` branch.
+* Configure your local workspace with Stonecutter before making changes:
+  * `./gradlew sc:useVersion -Psc.version=1.21.4`
+* Never force Gradle builds inside PRs. If validation is required, request a run
+  of the guarded CI workflow instead of pushing build artifacts.
+* If you are at risk of missing a deadline or experiencing local timeouts,
+  commit your progress and open a pull request with a clear TODO list so the
+  work stays unblocked.
 * Make commits of logical units.
 * Check for unnecessary whitespace with `git diff --check` before committing.
 * Make sure your commit messages are in the proper format.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Summary
+- [ ] Metadata ok
+- [ ] Registries ok
+- [ ] Networking ok
+- [ ] Capabilities ok
+- [ ] Worldgen ok
+- [ ] Loot ok
+- [ ] Recipes ok
+- [ ] Client ok
+- [ ] Interop ok
+
+## Checklist
+- [ ] I have not forced a Gradle build for this PR.
+- [ ] If validation is needed, I will trigger the guarded CI via `workflow_dispatch`.
+
+> Do not run builds unless asked. If validation is needed, trigger CI via `workflow_dispatch`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: AE2 CI (guarded)
+
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      run_build:
+        description: 'Run Gradle build'
+        required: false
+        default: 'false'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+      - name: Spotless check
+        run: ./gradlew spotlessCheck --console=plain
+
+  build:
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_build == 'true' }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        mc: [ '1.21.4', '1.21.9' ]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+      - name: Select Stonecutter target
+        run: ./gradlew sc:useVersion -Psc.version=${{ matrix.mc }}
+      - name: Build
+        run: ./gradlew clean build --no-daemon --stacktrace --console=plain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Applied Energistics 2 — Unreleased
+
+## Added
+- NeoForge 1.21.4 baseline
+- Stonecutter multi-version support
+
+## Networking
+- Payload-based networking stack
+
+## Capabilities
+- CapabilityToken adoption for capability registration
+
+## Worldgen
+- Biome modifier-driven world generation hooks
+
+## Loot
+- Global loot modifiers integration
+
+## Recipes
+- Codec-based recipe serializers
+
+## Client
+- Dist.CLIENT setup with screen registry catalog
+
+## Interop
+- JEI / REI / Curios bridges and API facades

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,18 @@ plugins {
 apply plugin: ProjectDefaultsPlugin
 apply plugin: CrowdinPlugin
 
+def describe = { ->
+    try {
+        "git describe --tags".execute().text.trim()
+    } catch (ignored) {
+        "0.1.0-SNAPSHOT"
+    }
+}
+
+if (!project.hasProperty("ae2.version.from.git")) {
+    version = describe()
+}
+
 base {
     archivesName = "appliedenergistics2"
 }

--- a/docs/DATAGEN_PLAN.md
+++ b/docs/DATAGEN_PLAN.md
@@ -1,0 +1,15 @@
+# Datagen Enablement Plan
+
+Datagen is currently deferred. When it is enabled, follow these steps to verify parity:
+
+1. Run the Stonecutter target datagen task:
+   ```sh
+   ./gradlew runData
+   ```
+2. Compare the generated JSON assets under `build/generated` to the legacy 1.21.1 exports.
+3. Validate parity across the following gates:
+   - Tags
+   - Recipes
+   - Loot tables
+   - World generation features
+   - Biome modifiers

--- a/docs/PORT_MATRIX.md
+++ b/docs/PORT_MATRIX.md
@@ -1,0 +1,14 @@
+# Stonecutter Port Validation Matrix
+
+Track the validated Stonecutter targets and the NeoForge builds used to certify them.
+Update this matrix when NeoForge publishes newer betas, and link each entry to the
+commit or pull request that validated the pairing.
+
+- [Default: 1.21.4 / 21.4.154](TBD)
+- [1.21.5 / 21.5.95](TBD)
+- [1.21.6 / 21.6.20-beta](TBD)
+- [1.21.7 / 21.7.25-beta](TBD)
+- [1.21.8 / 21.8.47](TBD)
+- [1.21.9 / 21.9.2-beta](TBD)
+
+> **Note:** Replace each `TBD` link target with the commit or PR that validated the version.

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,7 @@ org.gradle.configuration-cache=true
 org.gradle.warning.mode=all
 
 java_version=21
+version=0.1.0-SNAPSHOT
 
 #########################################################
 # Minecraft Versions                                    #


### PR DESCRIPTION
## Summary
- add a guarded GitHub Actions workflow with lint-by-default and optional build matrix for 1.21.4/1.21.9
- scaffold documentation for the Stonecutter port matrix, datagen plan, and release notes
- update contributor guidelines and Gradle configuration with version fallback and workflow expectations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0676045d48327a61be5493d3310af