### PR TITLE
Add stub AE2 registry entries

### DIFF
--- a/src/main/java/appeng/registry/AE2BlockEntities.java
+++ b/src/main/java/appeng/registry/AE2BlockEntities.java
@@ -1,0 +1,17 @@
+package appeng.registry;
+
+import appeng.AE2Registries;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.neoforged.neoforge.registries.RegistryObject;
+
+public final class AE2BlockEntities {
+    public static final RegistryObject<BlockEntityType<?>> INSCRIBER_BE =
+        AE2Registries.BLOCK_ENTITIES.register("inscriber",
+            () -> BlockEntityType.Builder.of(
+                // TODO: replace with InscriberBlockEntity::new
+                (pos, state) -> null,
+                AE2Blocks.INSCRIBER.get()
+            ).build(null));
+
+    private AE2BlockEntities() {}
+}

--- a/src/main/java/appeng/registry/AE2Blocks.java
+++ b/src/main/java/appeng/registry/AE2Blocks.java
@@ -1,0 +1,22 @@
+package appeng.registry;
+
+import appeng.AE2Registries;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.material.MapColor;
+import net.neoforged.neoforge.registries.RegistryObject;
+
+public final class AE2Blocks {
+    public static final RegistryObject<Block> CERTUS_QUARTZ_ORE = AE2Registries.BLOCKS.register(
+        "certus_quartz_ore",
+        () -> new Block(BlockBehaviour.Properties.of()
+            .mapColor(MapColor.STONE)
+            .strength(3.0f, 3.0f)));
+
+    public static final RegistryObject<Block> INSCRIBER = AE2Registries.BLOCKS.register(
+        "inscriber",
+        () -> new Block(BlockBehaviour.Properties.copy(Blocks.IRON_BLOCK)));
+
+    private AE2Blocks() {}
+}

--- a/src/main/java/appeng/registry/AE2Items.java
+++ b/src/main/java/appeng/registry/AE2Items.java
@@ -1,0 +1,19 @@
+package appeng.registry;
+
+import appeng.AE2Registries;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.Item.Properties;
+import net.neoforged.neoforge.registries.RegistryObject;
+
+public final class AE2Items {
+    public static final RegistryObject<Item> CERTUS_QUARTZ_CRYSTAL = AE2Registries.ITEMS.register(
+        "certus_quartz_crystal",
+        () -> new Item(new Properties()));
+
+    public static final RegistryObject<Item> INSCRIBER_BLOCK_ITEM = AE2Registries.ITEMS.register(
+        "inscriber",
+        () -> new BlockItem(AE2Blocks.INSCRIBER.get(), new Properties()));
+
+    private AE2Items() {}
+}

--- a/src/main/java/appeng/registry/AE2Menus.java
+++ b/src/main/java/appeng/registry/AE2Menus.java
@@ -1,0 +1,15 @@
+package appeng.registry;
+
+import appeng.AE2Registries;
+import net.minecraft.world.inventory.MenuType;
+import net.neoforged.neoforge.registries.RegistryObject;
+
+public final class AE2Menus {
+    public static final RegistryObject<MenuType<?>> INSCRIBER_MENU =
+        AE2Registries.MENUS.register("inscriber", () -> new MenuType<>((id, inv) -> {
+            // TODO: return new InscriberMenu(id, inv);
+            return null;
+        }));
+
+    private AE2Menus() {}
+}


### PR DESCRIPTION
## Summary
- add placeholder block and item registrations for Certus Quartz ore and the Inscriber
- stub out Inscriber menu and block entity registry objects for future implementation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0720e78708327a3acef17ac23cb6d