### PR TITLE
Add scaffolds for Inscriber and Charger blocks

### DIFF
--- a/src/main/java/appeng/blockentity/ChargerBlockEntity.java
+++ b/src/main/java/appeng/blockentity/ChargerBlockEntity.java
@@ -1,0 +1,17 @@
+package appeng.blockentity;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+
+import appeng.registry.AE2BlockEntities;
+
+public class ChargerBlockEntity extends BlockEntity {
+    public ChargerBlockEntity(BlockPos pos, BlockState state) {
+        super(AE2BlockEntities.CHARGER_BE.get(), pos, state);
+    }
+
+    public static void tick(BlockPos pos, BlockState state, ChargerBlockEntity be) {
+        // TODO: add charging logic
+    }
+}

--- a/src/main/java/appeng/blockentity/InscriberBlockEntity.java
+++ b/src/main/java/appeng/blockentity/InscriberBlockEntity.java
@@ -1,0 +1,17 @@
+package appeng.blockentity;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+
+import appeng.registry.AE2BlockEntities;
+
+public class InscriberBlockEntity extends BlockEntity {
+    public InscriberBlockEntity(BlockPos pos, BlockState state) {
+        super(AE2BlockEntities.INSCRIBER_BE.get(), pos, state);
+    }
+
+    public static void tick(BlockPos pos, BlockState state, InscriberBlockEntity be) {
+        // TODO: add processing logic
+    }
+}

--- a/src/main/java/appeng/client/AE2ClientSetup.java
+++ b/src/main/java/appeng/client/AE2ClientSetup.java
@@ -1,10 +1,15 @@
 package appeng.client;
 
+import net.minecraft.client.gui.screens.MenuScreens;
 import net.neoforged.api.distmarker.Dist;
-import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
+
 import appeng.AE2Registries;
+import appeng.client.screen.ChargerScreen;
+import appeng.client.screen.InscriberScreen;
+import appeng.registry.AE2Menus;
 
 @EventBusSubscriber(modid = AE2Registries.MODID, bus = EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
 public final class AE2ClientSetup {
@@ -13,7 +18,8 @@ public final class AE2ClientSetup {
     @SubscribeEvent
     public static void onClientSetup(FMLClientSetupEvent event) {
         event.enqueueWork(() -> {
-            // TODO: register MenuScreens and render layers
+            MenuScreens.register(AE2Menus.INSCRIBER_MENU.get(), InscriberScreen::new);
+            MenuScreens.register(AE2Menus.CHARGER_MENU.get(), ChargerScreen::new);
         });
     }
 }

--- a/src/main/java/appeng/client/screen/ChargerScreen.java
+++ b/src/main/java/appeng/client/screen/ChargerScreen.java
@@ -1,0 +1,18 @@
+package appeng.client.screen;
+
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Inventory;
+
+import appeng.menu.ChargerMenu;
+
+public class ChargerScreen extends AbstractContainerScreen<ChargerMenu> {
+    public ChargerScreen(ChargerMenu menu, Inventory inv, Component title) {
+        super(menu, inv, title);
+    }
+
+    @Override
+    protected void renderBg(net.minecraft.client.gui.GuiGraphics graphics, float partialTicks, int mouseX, int mouseY) {
+        // TODO: draw background
+    }
+}

--- a/src/main/java/appeng/client/screen/InscriberScreen.java
+++ b/src/main/java/appeng/client/screen/InscriberScreen.java
@@ -1,0 +1,18 @@
+package appeng.client.screen;
+
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Inventory;
+
+import appeng.menu.InscriberMenu;
+
+public class InscriberScreen extends AbstractContainerScreen<InscriberMenu> {
+    public InscriberScreen(InscriberMenu menu, Inventory inv, Component title) {
+        super(menu, inv, title);
+    }
+
+    @Override
+    protected void renderBg(net.minecraft.client.gui.GuiGraphics graphics, float partialTicks, int mouseX, int mouseY) {
+        // TODO: draw background
+    }
+}

--- a/src/main/java/appeng/menu/ChargerMenu.java
+++ b/src/main/java/appeng/menu/ChargerMenu.java
@@ -1,0 +1,19 @@
+package appeng.menu;
+
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+
+import appeng.registry.AE2Menus;
+
+public class ChargerMenu extends AbstractContainerMenu {
+    public ChargerMenu(int id, Inventory inv) {
+        super(AE2Menus.CHARGER_MENU.get(), id);
+        // TODO: slots
+    }
+
+    @Override
+    public boolean stillValid(Player player) {
+        return true;
+    }
+}

--- a/src/main/java/appeng/menu/InscriberMenu.java
+++ b/src/main/java/appeng/menu/InscriberMenu.java
@@ -1,0 +1,19 @@
+package appeng.menu;
+
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+
+import appeng.registry.AE2Menus;
+
+public class InscriberMenu extends AbstractContainerMenu {
+    public InscriberMenu(int id, Inventory inv) {
+        super(AE2Menus.INSCRIBER_MENU.get(), id);
+        // TODO: slots
+    }
+
+    @Override
+    public boolean stillValid(Player player) {
+        return true;
+    }
+}

--- a/src/main/java/appeng/registry/AE2BlockEntities.java
+++ b/src/main/java/appeng/registry/AE2BlockEntities.java
@@ -1,17 +1,21 @@
 package appeng.registry;
 
 import appeng.AE2Registries;
+import appeng.blockentity.ChargerBlockEntity;
+import appeng.blockentity.InscriberBlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.neoforged.neoforge.registries.RegistryObject;
 
 public final class AE2BlockEntities {
-    public static final RegistryObject<BlockEntityType<?>> INSCRIBER_BE =
+    public static final RegistryObject<BlockEntityType<InscriberBlockEntity>> INSCRIBER_BE =
         AE2Registries.BLOCK_ENTITIES.register("inscriber",
-            () -> BlockEntityType.Builder.of(
-                // TODO: replace with InscriberBlockEntity::new
-                (pos, state) -> null,
-                AE2Blocks.INSCRIBER.get()
-            ).build(null));
+            () -> BlockEntityType.Builder.of(InscriberBlockEntity::new,
+                AE2Blocks.INSCRIBER.get()).build(null));
+
+    public static final RegistryObject<BlockEntityType<ChargerBlockEntity>> CHARGER_BE =
+        AE2Registries.BLOCK_ENTITIES.register("charger",
+            () -> BlockEntityType.Builder.of(ChargerBlockEntity::new,
+                AE2Blocks.CHARGER.get()).build(null));
 
     private AE2BlockEntities() {}
 }

--- a/src/main/java/appeng/registry/AE2Menus.java
+++ b/src/main/java/appeng/registry/AE2Menus.java
@@ -1,15 +1,17 @@
 package appeng.registry;
 
 import appeng.AE2Registries;
+import appeng.menu.ChargerMenu;
+import appeng.menu.InscriberMenu;
 import net.minecraft.world.inventory.MenuType;
 import net.neoforged.neoforge.registries.RegistryObject;
 
 public final class AE2Menus {
-    public static final RegistryObject<MenuType<?>> INSCRIBER_MENU =
-        AE2Registries.MENUS.register("inscriber", () -> new MenuType<>((id, inv) -> {
-            // TODO: return new InscriberMenu(id, inv);
-            return null;
-        }));
+    public static final RegistryObject<MenuType<InscriberMenu>> INSCRIBER_MENU =
+        AE2Registries.MENUS.register("inscriber", () -> new MenuType<>(InscriberMenu::new));
+
+    public static final RegistryObject<MenuType<ChargerMenu>> CHARGER_MENU =
+        AE2Registries.MENUS.register("charger", () -> new MenuType<>(ChargerMenu::new));
 
     private AE2Menus() {}
 }


### PR DESCRIPTION
## Summary
- add scaffold BlockEntities, Menus, and Screens for the Inscriber and Charger
- register both block entities and menus with AE2 registries
- hook the client setup to display placeholder menu screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e07da85e7883279c8ea401d8e390dc