### PR TITLE
Add datagen providers for inscriber and charger recipes

### DIFF
--- a/src/main/java/appeng/datagen/AE2DataGenerators.java
+++ b/src/main/java/appeng/datagen/AE2DataGenerators.java
@@ -11,6 +11,12 @@ public final class AE2DataGenerators {
 
     @SubscribeEvent
     public static void gatherData(GatherDataEvent event) {
-        // TODO: wire providers
+        var generator = event.getGenerator();
+        var output = generator.getPackOutput();
+
+        if (event.includeServer()) {
+            generator.addProvider(true, new InscriberRecipeProvider(output));
+            generator.addProvider(true, new ChargerRecipeProvider(output));
+        }
     }
 }

--- a/src/main/java/appeng/datagen/ChargerRecipeProvider.java
+++ b/src/main/java/appeng/datagen/ChargerRecipeProvider.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2021, TeamAppliedEnergistics, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.datagen;
+
+import net.minecraft.data.PackOutput;
+import net.minecraft.data.recipes.RecipeOutput;
+import net.minecraft.data.recipes.RecipeProvider;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Items;
+
+import appeng.recipe.ChargerRecipe;
+
+public class ChargerRecipeProvider extends RecipeProvider {
+    public ChargerRecipeProvider(PackOutput output) {
+        super(output);
+    }
+
+    @Override
+    protected void buildRecipes(RecipeOutput output) {
+        output.accept(new ResourceLocation("appliedenergistics2", "charger/charged_quartz"),
+                new ChargerRecipe(
+                        Items.QUARTZ.getDefaultInstance(),
+                        Items.DIAMOND.getDefaultInstance(),
+                        200),
+                null);
+    }
+}

--- a/src/main/java/appeng/datagen/InscriberRecipeProvider.java
+++ b/src/main/java/appeng/datagen/InscriberRecipeProvider.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of Applied Energistics 2.
+ * Copyright (c) 2021, TeamAppliedEnergistics, All rights reserved.
+ *
+ * Applied Energistics 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Applied Energistics 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Applied Energistics 2.  If not, see <http://www.gnu.org/licenses/lgpl>.
+ */
+
+package appeng.datagen;
+
+import net.minecraft.data.PackOutput;
+import net.minecraft.data.recipes.RecipeOutput;
+import net.minecraft.data.recipes.RecipeProvider;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Items;
+
+import appeng.recipe.InscriberRecipe;
+
+public class InscriberRecipeProvider extends RecipeProvider {
+    public InscriberRecipeProvider(PackOutput output) {
+        super(output);
+    }
+
+    @Override
+    protected void buildRecipes(RecipeOutput output) {
+        output.accept(new ResourceLocation("appliedenergistics2", "inscriber/printed_silicon"),
+                new InscriberRecipe(
+                        Items.IRON_INGOT.getDefaultInstance(),
+                        Items.QUARTZ.getDefaultInstance(),
+                        Items.AIR.getDefaultInstance(),
+                        Items.DIAMOND.getDefaultInstance()),
+                null);
+    }
+}


### PR DESCRIPTION
## Summary
- register dedicated datagen providers for Inscriber and Charger recipes
- generate sample Inscriber and Charger recipes from code instead of static JSON

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e09145b6dc83278cfca938b9b2245b