### PR TITLE
Add data generators for AE2 tags and loot tables

### DIFF
--- a/src/main/java/appeng/datagen/AE2BlockTagsProvider.java
+++ b/src/main/java/appeng/datagen/AE2BlockTagsProvider.java
@@ -1,7 +1,28 @@
 package appeng.datagen;
 
-public final class AE2BlockTagsProvider {
-    public void generate() {
-        // TODO: implement block tags
+import java.util.concurrent.CompletableFuture;
+
+import net.minecraft.core.HolderLookup;
+import net.minecraft.data.PackOutput;
+import net.minecraft.data.tags.BlockTagsProvider;
+import net.minecraft.tags.BlockTags;
+import net.neoforged.neoforge.common.data.ExistingFileHelper;
+
+import appeng.AE2Registries;
+import appeng.registry.AE2Blocks;
+
+public class AE2BlockTagsProvider extends BlockTagsProvider {
+    public AE2BlockTagsProvider(PackOutput output,
+            CompletableFuture<HolderLookup.Provider> lookup,
+            ExistingFileHelper helper) {
+        super(output, lookup, AE2Registries.MODID, helper);
+    }
+
+    @Override
+    protected void addTags(HolderLookup.Provider provider) {
+        tag(BlockTags.MINEABLE_WITH_PICKAXE)
+                .add(AE2Blocks.CERTUS_QUARTZ_ORE.get())
+                .add(AE2Blocks.CHARGER.get())
+                .add(AE2Blocks.INSCRIBER.get());
     }
 }

--- a/src/main/java/appeng/datagen/AE2DataGenerators.java
+++ b/src/main/java/appeng/datagen/AE2DataGenerators.java
@@ -3,6 +3,7 @@ package appeng.datagen;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.neoforge.data.event.GatherDataEvent;
+
 import appeng.AE2Registries;
 
 @EventBusSubscriber(modid = AE2Registries.MODID, bus = EventBusSubscriber.Bus.MOD)
@@ -13,10 +14,15 @@ public final class AE2DataGenerators {
     public static void gatherData(GatherDataEvent event) {
         var generator = event.getGenerator();
         var output = generator.getPackOutput();
+        var helper = event.getExistingFileHelper();
+        var lookup = event.getLookupProvider();
 
         if (event.includeServer()) {
             generator.addProvider(true, new InscriberRecipeProvider(output));
             generator.addProvider(true, new ChargerRecipeProvider(output));
+            generator.addProvider(true, new AE2ItemTagsProvider(output, lookup, helper));
+            generator.addProvider(true, new AE2BlockTagsProvider(output, lookup, helper));
+            generator.addProvider(true, new AE2LootTableProvider(output));
         }
     }
 }

--- a/src/main/java/appeng/datagen/AE2ItemTagsProvider.java
+++ b/src/main/java/appeng/datagen/AE2ItemTagsProvider.java
@@ -1,7 +1,32 @@
 package appeng.datagen;
 
-public final class AE2ItemTagsProvider {
-    public void generate() {
-        // TODO: implement item tags
+import java.util.concurrent.CompletableFuture;
+
+import net.minecraft.core.HolderLookup;
+import net.minecraft.data.PackOutput;
+import net.minecraft.data.tags.ItemTagsProvider;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.ItemTags;
+import net.neoforged.neoforge.common.data.ExistingFileHelper;
+
+import appeng.AE2Registries;
+import appeng.registry.AE2Items;
+
+public class AE2ItemTagsProvider extends ItemTagsProvider {
+    public AE2ItemTagsProvider(PackOutput output,
+            CompletableFuture<HolderLookup.Provider> lookup,
+            ExistingFileHelper helper) {
+        super(output, lookup, AE2Registries.MODID, helper);
+    }
+
+    @Override
+    protected void addTags(HolderLookup.Provider provider) {
+        tag(ItemTags.GEMS_QUARTZ).add(AE2Items.CERTUS_QUARTZ_CRYSTAL.get());
+        tag(ItemTags.create(new ResourceLocation("forge", "silicon")))
+                .add(AE2Items.SILICON.get());
+        tag(ItemTags.create(new ResourceLocation("forge", "processors")))
+                .add(AE2Items.LOGIC_PROCESSOR.get())
+                .add(AE2Items.ENGINEERING_PROCESSOR.get())
+                .add(AE2Items.CALCULATION_PROCESSOR.get());
     }
 }

--- a/src/main/java/appeng/datagen/AE2LootTableProvider.java
+++ b/src/main/java/appeng/datagen/AE2LootTableProvider.java
@@ -1,7 +1,44 @@
 package appeng.datagen;
 
-public final class AE2LootTableProvider {
-    public void generate() {
-        // TODO: implement loot tables
+import java.util.List;
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+import net.minecraft.data.PackOutput;
+import net.minecraft.data.loot.LootTableProvider;
+import net.minecraft.data.loot.LootTableSubProvider;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.storage.loot.LootPool;
+import net.minecraft.world.level.storage.loot.LootTable;
+import net.minecraft.world.level.storage.loot.entries.LootItem;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParamSets;
+import net.minecraft.world.level.storage.loot.providers.number.ConstantValue;
+
+import appeng.registry.AE2Blocks;
+import appeng.registry.AE2Items;
+
+public class AE2LootTableProvider extends LootTableProvider {
+    public AE2LootTableProvider(PackOutput output) {
+        super(output, Set.of(), List.of(new SubProviderEntry(AE2BlockLoot::new, LootContextParamSets.BLOCK)));
+    }
+
+    private static class AE2BlockLoot implements LootTableSubProvider {
+        @Override
+        public void generate(BiConsumer<ResourceLocation, LootTable.Builder> out) {
+            out.accept(AE2Blocks.CERTUS_QUARTZ_ORE.getId(),
+                    LootTable.lootTable().withPool(
+                            LootPool.lootPool().setRolls(ConstantValue.exactly(1))
+                                    .add(LootItem.lootTableItem(AE2Items.CERTUS_QUARTZ_CRYSTAL.get()))));
+
+            out.accept(AE2Blocks.INSCRIBER.getId(),
+                    LootTable.lootTable().withPool(
+                            LootPool.lootPool().setRolls(ConstantValue.exactly(1))
+                                    .add(LootItem.lootTableItem(AE2Blocks.INSCRIBER.get()))));
+
+            out.accept(AE2Blocks.CHARGER.getId(),
+                    LootTable.lootTable().withPool(
+                            LootPool.lootPool().setRolls(ConstantValue.exactly(1))
+                                    .add(LootItem.lootTableItem(AE2Blocks.CHARGER.get()))));
+        }
     }
 }

--- a/src/main/java/appeng/registry/AE2Blocks.java
+++ b/src/main/java/appeng/registry/AE2Blocks.java
@@ -18,5 +18,9 @@ public final class AE2Blocks {
         "inscriber",
         () -> new Block(BlockBehaviour.Properties.copy(Blocks.IRON_BLOCK)));
 
+    public static final RegistryObject<Block> CHARGER = AE2Registries.BLOCKS.register(
+        "charger",
+        () -> new Block(BlockBehaviour.Properties.copy(Blocks.IRON_BLOCK)));
+
     private AE2Blocks() {}
 }


### PR DESCRIPTION
## Summary
- add item tag assignments for quartz, silicon, and processor items
- define block tags and loot tables for AE2 ore and machines
- register the new providers with the existing data generator setup

## Testing
- not run (data generation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68e095f11d288327b9a3fbf4423ae904