### PR TITLE
Add client datagen providers for AE2 assets

### DIFF
--- a/src/main/java/appeng/datagen/AE2BlockStateProvider.java
+++ b/src/main/java/appeng/datagen/AE2BlockStateProvider.java
@@ -1,0 +1,21 @@
+package appeng.datagen;
+
+import net.minecraft.data.PackOutput;
+import net.neoforged.neoforge.client.model.generators.BlockStateProvider;
+import net.neoforged.neoforge.common.data.ExistingFileHelper;
+
+import appeng.AE2Registries;
+import appeng.registry.AE2Blocks;
+
+public class AE2BlockStateProvider extends BlockStateProvider {
+    public AE2BlockStateProvider(PackOutput output, ExistingFileHelper helper) {
+        super(output, AE2Registries.MODID, helper);
+    }
+
+    @Override
+    protected void registerStatesAndModels() {
+        simpleBlock(AE2Blocks.CERTUS_QUARTZ_ORE.get());
+        simpleBlock(AE2Blocks.INSCRIBER.get());
+        simpleBlock(AE2Blocks.CHARGER.get());
+    }
+}

--- a/src/main/java/appeng/datagen/AE2DataGenerators.java
+++ b/src/main/java/appeng/datagen/AE2DataGenerators.java
@@ -24,5 +24,11 @@ public final class AE2DataGenerators {
             generator.addProvider(true, new AE2BlockTagsProvider(output, lookup, helper));
             generator.addProvider(true, new AE2LootTableProvider(output));
         }
+
+        if (event.includeClient()) {
+            generator.addProvider(true, new AE2BlockStateProvider(output, helper));
+            generator.addProvider(true, new AE2ItemModelProvider(output, helper));
+            generator.addProvider(true, new AE2LanguageProvider(output));
+        }
     }
 }

--- a/src/main/java/appeng/datagen/AE2ItemModelProvider.java
+++ b/src/main/java/appeng/datagen/AE2ItemModelProvider.java
@@ -1,0 +1,36 @@
+package appeng.datagen;
+
+import net.minecraft.data.PackOutput;
+import net.neoforged.neoforge.client.model.generators.ItemModelProvider;
+import net.neoforged.neoforge.common.data.ExistingFileHelper;
+
+import appeng.AE2Registries;
+import appeng.registry.AE2Items;
+
+public class AE2ItemModelProvider extends ItemModelProvider {
+    public AE2ItemModelProvider(PackOutput output, ExistingFileHelper helper) {
+        super(output, AE2Registries.MODID, helper);
+    }
+
+    @Override
+    protected void registerModels() {
+        withExistingParent(AE2Items.INSCRIBER.getId().getPath(), modLoc("block/inscriber"));
+        withExistingParent(AE2Items.CHARGER.getId().getPath(), modLoc("block/charger"));
+        withExistingParent(AE2Items.CERTUS_QUARTZ_ORE.getId().getPath(), modLoc("block/certus_quartz_ore"));
+
+        basicItem(AE2Items.SILICON.get());
+        basicItem(AE2Items.CERTUS_QUARTZ_CRYSTAL.get());
+        basicItem(AE2Items.CHARGED_CERTUS_QUARTZ_CRYSTAL.get());
+        basicItem(AE2Items.PRINTED_SILICON.get());
+        basicItem(AE2Items.PRINTED_LOGIC_PROCESSOR.get());
+        basicItem(AE2Items.PRINTED_ENGINEERING_PROCESSOR.get());
+        basicItem(AE2Items.PRINTED_CALCULATION_PROCESSOR.get());
+        basicItem(AE2Items.LOGIC_PROCESSOR.get());
+        basicItem(AE2Items.ENGINEERING_PROCESSOR.get());
+        basicItem(AE2Items.CALCULATION_PROCESSOR.get());
+        basicItem(AE2Items.INSCRIBER_SILICON_PRESS.get());
+        basicItem(AE2Items.INSCRIBER_LOGIC_PRESS.get());
+        basicItem(AE2Items.INSCRIBER_ENGINEERING_PRESS.get());
+        basicItem(AE2Items.INSCRIBER_CALCULATION_PRESS.get());
+    }
+}

--- a/src/main/java/appeng/datagen/AE2LanguageProvider.java
+++ b/src/main/java/appeng/datagen/AE2LanguageProvider.java
@@ -1,0 +1,34 @@
+package appeng.datagen;
+
+import net.minecraft.data.PackOutput;
+import net.neoforged.neoforge.common.data.LanguageProvider;
+
+import appeng.AE2Registries;
+
+public class AE2LanguageProvider extends LanguageProvider {
+    public AE2LanguageProvider(PackOutput output) {
+        super(output, AE2Registries.MODID, "en_us");
+    }
+
+    @Override
+    protected void addTranslations() {
+        add("block.appliedenergistics2.certus_quartz_ore", "Certus Quartz Ore");
+        add("block.appliedenergistics2.inscriber", "Inscriber");
+        add("block.appliedenergistics2.charger", "Charger");
+
+        add("item.appliedenergistics2.silicon", "Silicon");
+        add("item.appliedenergistics2.certus_quartz_crystal", "Certus Quartz Crystal");
+        add("item.appliedenergistics2.charged_certus_quartz_crystal", "Charged Certus Quartz Crystal");
+        add("item.appliedenergistics2.printed_silicon", "Printed Silicon");
+        add("item.appliedenergistics2.printed_logic_processor", "Printed Logic Circuit");
+        add("item.appliedenergistics2.printed_engineering_processor", "Printed Engineering Circuit");
+        add("item.appliedenergistics2.printed_calculation_processor", "Printed Calculation Circuit");
+        add("item.appliedenergistics2.logic_processor", "Logic Processor");
+        add("item.appliedenergistics2.engineering_processor", "Engineering Processor");
+        add("item.appliedenergistics2.calculation_processor", "Calculation Processor");
+        add("item.appliedenergistics2.inscriber_silicon_press", "Inscriber Silicon Press");
+        add("item.appliedenergistics2.inscriber_logic_press", "Inscriber Logic Press");
+        add("item.appliedenergistics2.inscriber_engineering_press", "Inscriber Engineering Press");
+        add("item.appliedenergistics2.inscriber_calculation_press", "Inscriber Calculation Press");
+    }
+}

--- a/src/main/java/appeng/registry/AE2Items.java
+++ b/src/main/java/appeng/registry/AE2Items.java
@@ -63,9 +63,17 @@ public final class AE2Items {
             "calculation_processor",
             () -> new Item(new Properties()));
 
-    public static final RegistryObject<Item> INSCRIBER_BLOCK_ITEM = AE2Registries.ITEMS.register(
+    public static final RegistryObject<Item> CERTUS_QUARTZ_ORE = AE2Registries.ITEMS.register(
+            "certus_quartz_ore",
+            () -> new BlockItem(AE2Blocks.CERTUS_QUARTZ_ORE.get(), new Properties()));
+
+    public static final RegistryObject<Item> INSCRIBER = AE2Registries.ITEMS.register(
             "inscriber",
             () -> new BlockItem(AE2Blocks.INSCRIBER.get(), new Properties()));
+
+    public static final RegistryObject<Item> CHARGER = AE2Registries.ITEMS.register(
+            "charger",
+            () -> new BlockItem(AE2Blocks.CHARGER.get(), new Properties()));
 
     private AE2Items() {}
 }


### PR DESCRIPTION
## Summary
- add blockstate, item model, and language datagen providers for AE2 content
- register the new providers with the client include stage of the data generator
- expose block item registry objects needed by the datagen providers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e09b5e91a88327acdb9abeab513fd4