### PR TITLE
Add datagen scaffolding for AE2 worldgen

### DIFF
--- a/src/main/java/appeng/datagen/AE2BiomeModifierProvider.java
+++ b/src/main/java/appeng/datagen/AE2BiomeModifierProvider.java
@@ -1,7 +1,47 @@
 package appeng.datagen;
 
-public final class AE2BiomeModifierProvider {
-    public void generate() {
-        // TODO: implement biome modifiers
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.HolderSet;
+import net.minecraft.core.RegistrySetBuilder;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.data.PackOutput;
+import net.minecraft.data.worldgen.BootstrapContext;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.levelgen.GenerationStep;
+import net.neoforged.neoforge.common.data.DatapackBuiltinEntriesProvider;
+import net.neoforged.neoforge.common.world.BiomeModifier;
+import net.neoforged.neoforge.common.world.BiomeModifiers;
+
+import appeng.AE2Registries;
+import appeng.worldgen.AE2Features;
+
+public class AE2BiomeModifierProvider extends DatapackBuiltinEntriesProvider {
+    private static final ResourceKey<BiomeModifier> ADD_CERTUS_QUARTZ = ResourceKey.create(
+        Registries.BIOME_MODIFIER, new ResourceLocation(AE2Registries.MODID, "add_certus_quartz_ore"));
+
+    public AE2BiomeModifierProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> registries) {
+        super(output, registries, createBuilder(), Set.of(AE2Registries.MODID));
+    }
+
+    private static RegistrySetBuilder createBuilder() {
+        return new RegistrySetBuilder().add(Registries.BIOME_MODIFIER, AE2BiomeModifierProvider::bootstrap);
+    }
+
+    private static void bootstrap(BootstrapContext<BiomeModifier> context) {
+        var biomes = context.lookup(Registries.BIOME);
+        var placedFeatures = context.lookup(Registries.PLACED_FEATURE);
+
+        var overworld = biomes.getOrThrow(ResourceKey.create(Registries.BIOME,
+            new ResourceLocation("minecraft", "overworld")));
+        var certusOre = placedFeatures.getOrThrow(AE2Features.CERTUS_QUARTZ_ORE_PLACED);
+
+        context.register(ADD_CERTUS_QUARTZ, new BiomeModifiers.AddFeaturesBiomeModifier(
+            HolderSet.direct(overworld),
+            HolderSet.direct(certusOre),
+            GenerationStep.Decoration.UNDERGROUND_ORES));
     }
 }

--- a/src/main/java/appeng/datagen/AE2DataGenerators.java
+++ b/src/main/java/appeng/datagen/AE2DataGenerators.java
@@ -23,6 +23,8 @@ public final class AE2DataGenerators {
             generator.addProvider(true, new AE2ItemTagsProvider(output, lookup, helper));
             generator.addProvider(true, new AE2BlockTagsProvider(output, lookup, helper));
             generator.addProvider(true, new AE2LootTableProvider(output));
+            generator.addProvider(true, new AE2WorldgenProvider(output, lookup));
+            generator.addProvider(true, new AE2BiomeModifierProvider(output, lookup));
         }
 
         if (event.includeClient()) {

--- a/src/main/java/appeng/datagen/AE2WorldgenProvider.java
+++ b/src/main/java/appeng/datagen/AE2WorldgenProvider.java
@@ -1,0 +1,63 @@
+package appeng.datagen;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.RegistrySetBuilder;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.data.PackOutput;
+import net.minecraft.data.worldgen.BootstrapContext;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.world.level.levelgen.VerticalAnchor;
+import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
+import net.minecraft.world.level.levelgen.feature.Feature;
+import net.minecraft.world.level.levelgen.feature.configurations.NoneFeatureConfiguration;
+import net.minecraft.world.level.levelgen.feature.configurations.OreConfiguration;
+import net.minecraft.world.level.levelgen.placement.CountPlacement;
+import net.minecraft.world.level.levelgen.placement.HeightRangePlacement;
+import net.minecraft.world.level.levelgen.placement.InSquarePlacement;
+import net.minecraft.world.level.levelgen.placement.PlacedFeature;
+import net.minecraft.world.level.levelgen.placement.PlacementModifier;
+import net.minecraft.world.level.levelgen.structure.templatesystem.RuleTest;
+import net.minecraft.world.level.levelgen.structure.templatesystem.TagMatchTest;
+import net.neoforged.neoforge.common.data.DatapackBuiltinEntriesProvider;
+
+import appeng.AE2Registries;
+import appeng.registry.AE2Blocks;
+import appeng.worldgen.AE2Features;
+
+public class AE2WorldgenProvider extends DatapackBuiltinEntriesProvider {
+    public AE2WorldgenProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> registries) {
+        super(output, registries, createBuilder(), Set.of(AE2Registries.MODID));
+    }
+
+    private static RegistrySetBuilder createBuilder() {
+        return new RegistrySetBuilder()
+            .add(Registries.CONFIGURED_FEATURE, AE2WorldgenProvider::bootstrapConfiguredFeatures)
+            .add(Registries.PLACED_FEATURE, AE2WorldgenProvider::bootstrapPlacedFeatures);
+    }
+
+    private static void bootstrapConfiguredFeatures(BootstrapContext<ConfiguredFeature<?, ?>> context) {
+        RuleTest stoneReplaceable = new TagMatchTest(BlockTags.STONE_ORE_REPLACEABLES);
+
+        OreConfiguration certusConfig = new OreConfiguration(stoneReplaceable,
+            AE2Blocks.CERTUS_QUARTZ_ORE.get().defaultBlockState(), 8);
+        context.register(AE2Features.CERTUS_QUARTZ_ORE, new ConfiguredFeature<>(Feature.ORE, certusConfig));
+
+        context.register(AE2Features.METEORITE,
+            new ConfiguredFeature<>(Feature.NO_OP, NoneFeatureConfiguration.INSTANCE));
+    }
+
+    private static void bootstrapPlacedFeatures(BootstrapContext<PlacedFeature> context) {
+        List<PlacementModifier> certusPlacement = List.of(
+            CountPlacement.of(8),
+            InSquarePlacement.spread(),
+            HeightRangePlacement.uniform(VerticalAnchor.absolute(-64), VerticalAnchor.absolute(64))
+        );
+
+        var configured = context.lookup(Registries.CONFIGURED_FEATURE).getOrThrow(AE2Features.CERTUS_QUARTZ_ORE);
+        context.register(AE2Features.CERTUS_QUARTZ_ORE_PLACED, new PlacedFeature(configured, certusPlacement));
+    }
+}

--- a/src/main/java/appeng/worldgen/AE2Features.java
+++ b/src/main/java/appeng/worldgen/AE2Features.java
@@ -1,38 +1,25 @@
 package appeng.worldgen;
 
-import appeng.core.AppEng;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.level.levelgen.VerticalAnchor;
 import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
-import net.minecraft.world.level.levelgen.feature.configurations.OreConfiguration;
-import net.minecraft.world.level.levelgen.placement.BiomeFilter;
-import net.minecraft.world.level.levelgen.placement.CountPlacement;
-import net.minecraft.world.level.levelgen.placement.HeightRangePlacement;
-import net.minecraft.world.level.levelgen.placement.InSquarePlacement;
 import net.minecraft.world.level.levelgen.placement.PlacedFeature;
-import net.minecraft.world.level.levelgen.placement.PlacementModifier;
 
-import java.util.List;
+import appeng.AE2Registries;
 
 public final class AE2Features {
-    private AE2Features() {
-    }
+    public static final ResourceKey<ConfiguredFeature<?, ?>> CERTUS_QUARTZ_ORE =
+        ResourceKey.create(Registries.CONFIGURED_FEATURE,
+            new ResourceLocation(AE2Registries.MODID, "certus_quartz_ore"));
 
-    public static final ResourceKey<ConfiguredFeature<?, ?>> CERTUS_ORE_CONFIG = ResourceKey.create(
-            Registries.CONFIGURED_FEATURE, new ResourceLocation(AppEng.MOD_ID, "certus_ore"));
-    public static final ResourceKey<PlacedFeature> CERTUS_ORE_PLACED = ResourceKey.create(Registries.PLACED_FEATURE,
-            new ResourceLocation(AppEng.MOD_ID, "certus_ore"));
+    public static final ResourceKey<PlacedFeature> CERTUS_QUARTZ_ORE_PLACED =
+        ResourceKey.create(Registries.PLACED_FEATURE,
+            new ResourceLocation(AE2Registries.MODID, "certus_quartz_ore"));
 
-    public static final ResourceKey<ConfiguredFeature<?, ?>> METEORITE_CONFIG = ResourceKey.create(
-            Registries.CONFIGURED_FEATURE, new ResourceLocation(AppEng.MOD_ID, "meteorite"));
-    public static final ResourceKey<PlacedFeature> METEORITE_PLACED = ResourceKey.create(Registries.PLACED_FEATURE,
-            new ResourceLocation(AppEng.MOD_ID, "meteorite"));
+    public static final ResourceKey<ConfiguredFeature<?, ?>> METEORITE =
+        ResourceKey.create(Registries.CONFIGURED_FEATURE,
+            new ResourceLocation(AE2Registries.MODID, "meteorite"));
 
-    public static List<PlacementModifier> orePlacement(int veinsPerChunk, int minY, int maxY) {
-        return List.of(CountPlacement.of(veinsPerChunk), InSquarePlacement.spread(),
-                HeightRangePlacement.uniform(VerticalAnchor.absolute(minY), VerticalAnchor.absolute(maxY)),
-                BiomeFilter.biome());
-    }
+    private AE2Features() {}
 }


### PR DESCRIPTION
## Summary
- define resource keys for the certus quartz ore and meteorite worldgen features
- add datagen providers that emit configured/placed features and the biome modifier for certus quartz ore
- hook the new providers into the server-side AE2 datagen pipeline

## Testing
- not run (datagen changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e09e8014348327856a19ae2bb5deca