### PR TITLE
Scaffold meteorite worldgen with sky stone placeholders

### DIFF
--- a/src/main/java/appeng/datagen/AE2BiomeModifierProvider.java
+++ b/src/main/java/appeng/datagen/AE2BiomeModifierProvider.java
@@ -22,6 +22,8 @@ import appeng.worldgen.AE2Features;
 public class AE2BiomeModifierProvider extends DatapackBuiltinEntriesProvider {
     private static final ResourceKey<BiomeModifier> ADD_CERTUS_QUARTZ = ResourceKey.create(
         Registries.BIOME_MODIFIER, new ResourceLocation(AE2Registries.MODID, "add_certus_quartz_ore"));
+    private static final ResourceKey<BiomeModifier> ADD_METEORITES = ResourceKey.create(
+        Registries.BIOME_MODIFIER, new ResourceLocation(AE2Registries.MODID, "add_meteorites"));
 
     public AE2BiomeModifierProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> registries) {
         super(output, registries, createBuilder(), Set.of(AE2Registries.MODID));
@@ -43,5 +45,11 @@ public class AE2BiomeModifierProvider extends DatapackBuiltinEntriesProvider {
             HolderSet.direct(overworld),
             HolderSet.direct(certusOre),
             GenerationStep.Decoration.UNDERGROUND_ORES));
+
+        var meteoriteFeature = placedFeatures.getOrThrow(AE2Features.METEORITE_PLACED);
+        context.register(ADD_METEORITES, new BiomeModifiers.AddFeaturesBiomeModifier(
+            HolderSet.direct(overworld),
+            HolderSet.direct(meteoriteFeature),
+            GenerationStep.Decoration.SURFACE_STRUCTURES));
     }
 }

--- a/src/main/java/appeng/datagen/AE2WorldgenProvider.java
+++ b/src/main/java/appeng/datagen/AE2WorldgenProvider.java
@@ -13,19 +13,21 @@ import net.minecraft.tags.BlockTags;
 import net.minecraft.world.level.levelgen.VerticalAnchor;
 import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
 import net.minecraft.world.level.levelgen.feature.Feature;
-import net.minecraft.world.level.levelgen.feature.configurations.NoneFeatureConfiguration;
 import net.minecraft.world.level.levelgen.feature.configurations.OreConfiguration;
+import net.minecraft.world.level.levelgen.placement.BiomeFilter;
 import net.minecraft.world.level.levelgen.placement.CountPlacement;
 import net.minecraft.world.level.levelgen.placement.HeightRangePlacement;
 import net.minecraft.world.level.levelgen.placement.InSquarePlacement;
 import net.minecraft.world.level.levelgen.placement.PlacedFeature;
 import net.minecraft.world.level.levelgen.placement.PlacementModifier;
+import net.minecraft.world.level.levelgen.placement.RarityFilter;
 import net.minecraft.world.level.levelgen.structure.templatesystem.RuleTest;
 import net.minecraft.world.level.levelgen.structure.templatesystem.TagMatchTest;
 import net.neoforged.neoforge.common.data.DatapackBuiltinEntriesProvider;
 
 import appeng.AE2Registries;
 import appeng.registry.AE2Blocks;
+import appeng.worldgen.config.SphereReplaceConfig;
 import appeng.worldgen.AE2Features;
 
 public class AE2WorldgenProvider extends DatapackBuiltinEntriesProvider {
@@ -46,8 +48,11 @@ public class AE2WorldgenProvider extends DatapackBuiltinEntriesProvider {
             AE2Blocks.CERTUS_QUARTZ_ORE.get().defaultBlockState(), 8);
         context.register(AE2Features.CERTUS_QUARTZ_ORE, new ConfiguredFeature<>(Feature.ORE, certusConfig));
 
-        context.register(AE2Features.METEORITE,
-            new ConfiguredFeature<>(Feature.NO_OP, NoneFeatureConfiguration.INSTANCE));
+        SphereReplaceConfig meteoriteConfig = new SphereReplaceConfig(
+            AE2Blocks.SKY_STONE.get().defaultBlockState(),
+            8,
+            16);
+        context.register(AE2Features.METEORITE, new ConfiguredFeature<>(Feature.DISK, meteoriteConfig));
     }
 
     private static void bootstrapPlacedFeatures(BootstrapContext<PlacedFeature> context) {
@@ -57,7 +62,16 @@ public class AE2WorldgenProvider extends DatapackBuiltinEntriesProvider {
             HeightRangePlacement.uniform(VerticalAnchor.absolute(-64), VerticalAnchor.absolute(64))
         );
 
-        var configured = context.lookup(Registries.CONFIGURED_FEATURE).getOrThrow(AE2Features.CERTUS_QUARTZ_ORE);
-        context.register(AE2Features.CERTUS_QUARTZ_ORE_PLACED, new PlacedFeature(configured, certusPlacement));
+        var configured = context.lookup(Registries.CONFIGURED_FEATURE);
+        var certus = configured.getOrThrow(AE2Features.CERTUS_QUARTZ_ORE);
+        context.register(AE2Features.CERTUS_QUARTZ_ORE_PLACED, new PlacedFeature(certus, certusPlacement));
+
+        List<PlacementModifier> meteoritePlacement = List.of(
+            RarityFilter.onAverageOnceEvery(200),
+            InSquarePlacement.spread(),
+            HeightRangePlacement.uniform(VerticalAnchor.absolute(20), VerticalAnchor.absolute(80)),
+            BiomeFilter.biome());
+        var meteorite = configured.getOrThrow(AE2Features.METEORITE);
+        context.register(AE2Features.METEORITE_PLACED, new PlacedFeature(meteorite, meteoritePlacement));
     }
 }

--- a/src/main/java/appeng/registry/AE2Blocks.java
+++ b/src/main/java/appeng/registry/AE2Blocks.java
@@ -22,5 +22,11 @@ public final class AE2Blocks {
         "charger",
         () -> new Block(BlockBehaviour.Properties.copy(Blocks.IRON_BLOCK)));
 
+    public static final RegistryObject<Block> SKY_STONE = AE2Registries.BLOCKS.register(
+        "sky_stone",
+        () -> new Block(BlockBehaviour.Properties.of()
+            .mapColor(MapColor.COLOR_BLACK)
+            .strength(50.0f, 1200.0f)));
+
     private AE2Blocks() {}
 }

--- a/src/main/java/appeng/registry/AE2Items.java
+++ b/src/main/java/appeng/registry/AE2Items.java
@@ -75,5 +75,9 @@ public final class AE2Items {
             "charger",
             () -> new BlockItem(AE2Blocks.CHARGER.get(), new Properties()));
 
+    public static final RegistryObject<Item> SKY_STONE = AE2Registries.ITEMS.register(
+            "sky_stone",
+            () -> new BlockItem(AE2Blocks.SKY_STONE.get(), new Properties()));
+
     private AE2Items() {}
 }

--- a/src/main/java/appeng/worldgen/AE2Features.java
+++ b/src/main/java/appeng/worldgen/AE2Features.java
@@ -21,5 +21,9 @@ public final class AE2Features {
         ResourceKey.create(Registries.CONFIGURED_FEATURE,
             new ResourceLocation(AE2Registries.MODID, "meteorite"));
 
+    public static final ResourceKey<PlacedFeature> METEORITE_PLACED =
+        ResourceKey.create(Registries.PLACED_FEATURE,
+            new ResourceLocation(AE2Registries.MODID, "meteorite"));
+
     private AE2Features() {}
 }

--- a/src/main/java/appeng/worldgen/config/SphereReplaceConfig.java
+++ b/src/main/java/appeng/worldgen/config/SphereReplaceConfig.java
@@ -1,0 +1,21 @@
+package appeng.worldgen.config;
+
+import java.util.List;
+
+import net.minecraft.util.valueproviders.UniformInt;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.levelgen.feature.configurations.DiskConfiguration;
+import net.minecraft.world.level.levelgen.feature.stateproviders.SimpleStateProvider;
+
+/**
+ * Placeholder configuration translating a spherical replace request into the
+ * vanilla disk feature configuration. This will be replaced with a dedicated
+ * meteorite feature once available.
+ */
+public class SphereReplaceConfig extends DiskConfiguration {
+    public SphereReplaceConfig(BlockState state, int minRadius, int maxRadius) {
+        super(SimpleStateProvider.simple(state), UniformInt.of(minRadius, maxRadius), maxRadius,
+            List.of(Blocks.STONE.defaultBlockState(), Blocks.DEEPSLATE.defaultBlockState()));
+    }
+}

--- a/src/main/resources/data/appliedenergistics2/loot_tables/chests/meteorite.json
+++ b/src/main/resources/data/appliedenergistics2/loot_tables/chests/meteorite.json
@@ -1,0 +1,14 @@
+{
+  "type": "minecraft:chest",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        { "type": "item", "name": "appliedenergistics2:inscriber_silicon_press" },
+        { "type": "item", "name": "appliedenergistics2:inscriber_logic_press" },
+        { "type": "item", "name": "appliedenergistics2:inscriber_engineering_press" },
+        { "type": "item", "name": "appliedenergistics2:inscriber_calculation_press" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- register a sky stone block and item for meteorite generation scaffolding
- add configured/placed meteorite features and biome modifier wiring
- stub in a meteorite loot table containing the inscriber presses

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e168865c748327886cd2e51a08317b