### PR TITLE
Add Sky Stone blockstate and item model datagen

### DIFF
--- a/src/main/java/appeng/datagen/AE2BlockStateProvider.java
+++ b/src/main/java/appeng/datagen/AE2BlockStateProvider.java
@@ -17,5 +17,6 @@ public class AE2BlockStateProvider extends BlockStateProvider {
         simpleBlock(AE2Blocks.CERTUS_QUARTZ_ORE.get());
         simpleBlock(AE2Blocks.INSCRIBER.get());
         simpleBlock(AE2Blocks.CHARGER.get());
+        simpleBlock(AE2Blocks.SKY_STONE.get());
     }
 }

--- a/src/main/java/appeng/datagen/AE2ItemModelProvider.java
+++ b/src/main/java/appeng/datagen/AE2ItemModelProvider.java
@@ -17,6 +17,7 @@ public class AE2ItemModelProvider extends ItemModelProvider {
         withExistingParent(AE2Items.INSCRIBER.getId().getPath(), modLoc("block/inscriber"));
         withExistingParent(AE2Items.CHARGER.getId().getPath(), modLoc("block/charger"));
         withExistingParent(AE2Items.CERTUS_QUARTZ_ORE.getId().getPath(), modLoc("block/certus_quartz_ore"));
+        withExistingParent(AE2Items.SKY_STONE.getId().getPath(), modLoc("block/sky_stone"));
 
         basicItem(AE2Items.SILICON.get());
         basicItem(AE2Items.CERTUS_QUARTZ_CRYSTAL.get());

--- a/src/main/java/appeng/datagen/AE2LanguageProvider.java
+++ b/src/main/java/appeng/datagen/AE2LanguageProvider.java
@@ -15,6 +15,7 @@ public class AE2LanguageProvider extends LanguageProvider {
         add("block.appliedenergistics2.certus_quartz_ore", "Certus Quartz Ore");
         add("block.appliedenergistics2.inscriber", "Inscriber");
         add("block.appliedenergistics2.charger", "Charger");
+        add("block.appliedenergistics2.sky_stone", "Sky Stone");
 
         add("item.appliedenergistics2.silicon", "Silicon");
         add("item.appliedenergistics2.certus_quartz_crystal", "Certus Quartz Crystal");


### PR DESCRIPTION
## Summary
- include Sky Stone in blockstate, item model, and language datagen providers
- ensure generated assets reference the existing block and item identifiers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e189065c348327930dd97ef04f33d7