### PR TITLE
Add placeholder grid node capability scaffolding

### DIFF
--- a/src/main/java/appeng/AE2Capabilities.java
+++ b/src/main/java/appeng/AE2Capabilities.java
@@ -1,0 +1,14 @@
+package appeng;
+
+import net.neoforged.neoforge.capabilities.Capability;
+import net.neoforged.neoforge.capabilities.CapabilityToken;
+
+import appeng.api.grid.IGridNode;
+
+public final class AE2Capabilities {
+    public static final Capability<IGridNode> GRID_NODE = new CapabilityToken<>() {
+    };
+
+    private AE2Capabilities() {
+    }
+}

--- a/src/main/java/appeng/api/grid/IGridHost.java
+++ b/src/main/java/appeng/api/grid/IGridHost.java
@@ -1,0 +1,14 @@
+package appeng.api.grid;
+
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Basic host interface for exposing a single AE2 grid node via capabilities.
+ */
+public interface IGridHost {
+    /**
+     * @return The exposed grid node, or {@code null} if the host is not currently connected.
+     */
+    @Nullable
+    IGridNode getGridNode();
+}

--- a/src/main/java/appeng/api/grid/IGridNode.java
+++ b/src/main/java/appeng/api/grid/IGridNode.java
@@ -1,0 +1,8 @@
+package appeng.api.grid;
+
+/**
+ * Placeholder grid node interface for future capability-based integration.
+ */
+public interface IGridNode {
+    // TODO: Add network management functions
+}

--- a/src/main/java/appeng/blockentity/misc/ChargerBlockEntity.java
+++ b/src/main/java/appeng/blockentity/misc/ChargerBlockEntity.java
@@ -34,6 +34,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import appeng.api.config.Actionable;
 import appeng.api.config.PowerMultiplier;
 import appeng.api.config.PowerUnit;
+import appeng.api.grid.IGridHost;
 import appeng.api.implementations.blockentities.ICrankable;
 import appeng.api.implementations.items.IAEItemPowerStorage;
 import appeng.api.inventories.InternalInventory;
@@ -52,12 +53,15 @@ import appeng.util.Platform;
 import appeng.util.inv.AppEngInternalInventory;
 import appeng.util.inv.filter.IAEItemFilter;
 
-public class ChargerBlockEntity extends AENetworkedPoweredBlockEntity implements IGridTickable {
+public class ChargerBlockEntity extends AENetworkedPoweredBlockEntity implements IGridTickable, IGridHost {
     public static final int POWER_MAXIMUM_AMOUNT = 1600;
     private static final int POWER_THRESHOLD = POWER_MAXIMUM_AMOUNT - 1;
     private boolean working;
 
     private final AppEngInternalInventory inv = new AppEngInternalInventory(this, 1, 1, new ChargerInvFilter(this));
+    private final appeng.api.grid.IGridNode gridNode = new appeng.api.grid.IGridNode() {
+        // TODO: Hook up real grid node once capability is fully implemented.
+    };
 
     public ChargerBlockEntity(BlockEntityType<?> blockEntityType, BlockPos pos, BlockState blockState) {
         super(blockEntityType, pos, blockState);
@@ -67,6 +71,11 @@ public class ChargerBlockEntity extends AENetworkedPoweredBlockEntity implements
                 .addService(IGridTickable.class, this);
         this.setInternalMaxPower(POWER_MAXIMUM_AMOUNT);
         this.setPowerSides(getGridConnectableSides(getOrientation()));
+    }
+
+    @Override
+    public appeng.api.grid.IGridNode getGridNode() {
+        return gridNode;
     }
 
     @Override

--- a/src/main/java/appeng/blockentity/misc/InscriberBlockEntity.java
+++ b/src/main/java/appeng/blockentity/misc/InscriberBlockEntity.java
@@ -43,6 +43,7 @@ import appeng.api.config.PowerMultiplier;
 import appeng.api.config.Setting;
 import appeng.api.config.Settings;
 import appeng.api.config.YesNo;
+import appeng.api.grid.IGridHost;
 import appeng.api.implementations.blockentities.ICrankable;
 import appeng.api.inventories.ISegmentedInventory;
 import appeng.api.inventories.InternalInventory;
@@ -78,7 +79,7 @@ import appeng.util.inv.filter.IAEItemFilter;
  * @since rv0
  */
 public class InscriberBlockEntity extends AENetworkedPoweredBlockEntity
-        implements IGridTickable, IUpgradeableObject, IConfigurableObject {
+        implements IGridTickable, IUpgradeableObject, IConfigurableObject, IGridHost {
     private static final int MAX_PROCESSING_STEPS = 200;
 
     private final IUpgradeInventory upgrades;
@@ -93,6 +94,10 @@ public class InscriberBlockEntity extends AENetworkedPoweredBlockEntity
     private boolean repeatSmash;
     private int finalStep;
     private long clientStart;
+
+    private final appeng.api.grid.IGridNode gridNode = new appeng.api.grid.IGridNode() {
+        // TODO: Hook up real grid node once capability is fully implemented.
+    };
 
     // Internally visible inventories
     private final IAEItemFilter baseFilter = new BaseFilter();
@@ -141,6 +146,11 @@ public class InscriberBlockEntity extends AENetworkedPoweredBlockEntity
                 sideItemHandlerExtern);
 
         this.setPowerSides(getGridConnectableSides(getOrientation()));
+    }
+
+    @Override
+    public appeng.api.grid.IGridNode getGridNode() {
+        return gridNode;
     }
 
     @Override

--- a/src/main/java/appeng/capability/AE2CapabilityAttach.java
+++ b/src/main/java/appeng/capability/AE2CapabilityAttach.java
@@ -8,6 +8,8 @@ import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.event.AttachCapabilitiesEvent;
 
+import appeng.api.grid.IGridHost;
+import appeng.capability.provider.GridNodeCapabilityProvider;
 import appeng.capability.provider.InWorldGridNodeHostProvider;
 import appeng.api.networking.IInWorldGridNodeHost;
 import appeng.core.AppEng;
@@ -26,6 +28,9 @@ public final class AE2CapabilityAttach {
         final BlockEntity be = event.getObject();
         if (be instanceof IInWorldGridNodeHost host) {
             event.addCapability(rl("inworld_gridnode_host"), new InWorldGridNodeHostProvider(be, host));
+        }
+        if (be instanceof IGridHost host) {
+            event.addCapability(rl("grid_node"), new GridNodeCapabilityProvider(be, host));
         }
     }
 

--- a/src/main/java/appeng/capability/provider/GridNodeCapabilityProvider.java
+++ b/src/main/java/appeng/capability/provider/GridNodeCapabilityProvider.java
@@ -1,0 +1,34 @@
+package appeng.capability.provider;
+
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.neoforged.neoforge.capabilities.Capability;
+
+import appeng.AE2Capabilities;
+import appeng.api.grid.IGridHost;
+import appeng.api.grid.IGridNode;
+
+/**
+ * Capability provider that exposes the placeholder grid node capability for AE2 block entities.
+ */
+public final class GridNodeCapabilityProvider extends AE2BlockEntityCapabilityProvider {
+    private final IGridHost host;
+
+    public GridNodeCapabilityProvider(BlockEntity be, IGridHost host) {
+        super(be);
+        this.host = host;
+    }
+
+    @Override
+    public <T> T getCapability(BlockEntity object, Capability<T> cap, @Nullable Direction side) {
+        if (cap == AE2Capabilities.GRID_NODE) {
+            IGridNode node = host.getGridNode();
+            if (node != null) {
+                return AE2Capabilities.GRID_NODE.cast(node);
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/appeng/interop/AE2Interop.java
+++ b/src/main/java/appeng/interop/AE2Interop.java
@@ -1,0 +1,25 @@
+package appeng.interop;
+
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.world.level.block.entity.BlockEntity;
+
+import appeng.AE2Capabilities;
+import appeng.api.grid.IGridNode;
+
+/**
+ * Simple helpers for third-party integrations to query AE2 grid node capabilities.
+ */
+public final class AE2Interop {
+    private AE2Interop() {
+    }
+
+    public static boolean hasGridNode(BlockEntity be) {
+        return getGridNode(be) != null;
+    }
+
+    @Nullable
+    public static IGridNode getGridNode(BlockEntity be) {
+        return be.getCapability(AE2Capabilities.GRID_NODE, null);
+    }
+}

--- a/src/main/java/appeng/util/GridHelper.java
+++ b/src/main/java/appeng/util/GridHelper.java
@@ -1,0 +1,24 @@
+package appeng.util;
+
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.world.level.block.entity.BlockEntity;
+
+import appeng.api.grid.IGridHost;
+import appeng.api.grid.IGridNode;
+
+/**
+ * Utility helpers for working with grid-hosting block entities via capabilities.
+ */
+public final class GridHelper {
+    private GridHelper() {
+    }
+
+    @Nullable
+    public static IGridNode getNode(BlockEntity be) {
+        if (be instanceof IGridHost host) {
+            return host.getGridNode();
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- add new grid API stubs and capability token for exposing grid nodes via NeoForge capabilities
- wire Inscriber and Charger block entities along with a provider to surface the placeholder grid node
- supply helpers for capability lookup and third-party interop

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e18c12450c8327894598f5989f1e45