### PR TITLE
Add storage API scaffolding

### DIFF
--- a/src/main/java/appeng/AE2Capabilities.java
+++ b/src/main/java/appeng/AE2Capabilities.java
@@ -4,9 +4,12 @@ import net.neoforged.neoforge.capabilities.Capability;
 import net.neoforged.neoforge.capabilities.CapabilityToken;
 
 import appeng.api.grid.IGridNode;
+import appeng.api.storage.IStorageService;
 
 public final class AE2Capabilities {
     public static final Capability<IGridNode> GRID_NODE = new CapabilityToken<>() {
+    };
+    public static final Capability<IStorageService> STORAGE_SERVICE = new CapabilityToken<>() {
     };
 
     private AE2Capabilities() {

--- a/src/main/java/appeng/api/storage/IStorageChannel.java
+++ b/src/main/java/appeng/api/storage/IStorageChannel.java
@@ -1,0 +1,46 @@
+package appeng.api.storage;
+
+import java.util.Collection;
+
+/**
+ * Represents a storage channel capable of storing, extracting and querying a specific type of
+ * resource.
+ *
+ * @param <T> The type of resource handled by the channel.
+ */
+public interface IStorageChannel<T> {
+    /**
+     * Attempts to insert the specified amount of a resource into this storage channel.
+     *
+     * @param resource The resource to insert.
+     * @param amount   The amount of the resource to insert.
+     * @param simulate If {@code true}, the operation should only be simulated.
+     * @return The amount of the resource that was accepted by the channel.
+     */
+    long insert(T resource, long amount, boolean simulate);
+
+    /**
+     * Attempts to extract the specified amount of a resource from this storage channel.
+     *
+     * @param resource The resource to extract.
+     * @param amount   The amount of the resource to extract.
+     * @param simulate If {@code true}, the operation should only be simulated.
+     * @return The amount of the resource that was successfully extracted from the channel.
+     */
+    long extract(T resource, long amount, boolean simulate);
+
+    /**
+     * Gets the total amount of the specified resource stored in this channel.
+     *
+     * @param resource The resource to query.
+     * @return The amount of the resource currently stored.
+     */
+    long getStoredAmount(T resource);
+
+    /**
+     * Gets a collection of all resources currently stored in this channel.
+     *
+     * @return The resources currently available in this channel.
+     */
+    Collection<T> getAll();
+}

--- a/src/main/java/appeng/api/storage/IStorageHost.java
+++ b/src/main/java/appeng/api/storage/IStorageHost.java
@@ -1,0 +1,13 @@
+package appeng.api.storage;
+
+/**
+ * Represents a component that exposes an {@link IStorageService}.
+ */
+public interface IStorageHost {
+    /**
+     * Gets the storage service provided by this host.
+     *
+     * @return The storage service, or {@code null} if none is available.
+     */
+    IStorageService getStorageService();
+}

--- a/src/main/java/appeng/api/storage/IStorageService.java
+++ b/src/main/java/appeng/api/storage/IStorageService.java
@@ -1,0 +1,24 @@
+package appeng.api.storage;
+
+import java.util.List;
+
+/**
+ * Provides access to the storage channels exposed by a storage host.
+ */
+public interface IStorageService {
+    /**
+     * Gets a storage channel for the specified resource type.
+     *
+     * @param type The type handled by the requested channel.
+     * @param <T>  The resource type handled by the channel.
+     * @return The channel if available, or {@code null}.
+     */
+    <T> IStorageChannel<T> getChannel(Class<T> type);
+
+    /**
+     * Gets all storage channels currently exposed by this service.
+     *
+     * @return The available channels.
+     */
+    List<IStorageChannel<?>> getAllChannels();
+}

--- a/src/main/java/appeng/blockentity/InscriberBlockEntity.java
+++ b/src/main/java/appeng/blockentity/InscriberBlockEntity.java
@@ -1,5 +1,8 @@
 package appeng.blockentity;
 
+import java.util.Collections;
+import java.util.List;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.NonNullList;
 import net.minecraft.nbt.CompoundTag;
@@ -7,19 +10,21 @@ import net.minecraft.world.Container;
 import net.minecraft.world.ContainerHelper;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeManager;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 
-import net.minecraft.world.item.crafting.RecipeManager;
-
 import net.neoforged.neoforge.items.wrapper.InvWrapper;
 
+import appeng.api.storage.IStorageChannel;
+import appeng.api.storage.IStorageHost;
+import appeng.api.storage.IStorageService;
 import appeng.registry.AE2BlockEntities;
 import appeng.recipe.AE2RecipeTypes;
 import appeng.recipe.InscriberRecipe;
 
-public class InscriberBlockEntity extends BlockEntity {
+public class InscriberBlockEntity extends BlockEntity implements IStorageHost {
     private final NonNullList<ItemStack> items = NonNullList.withSize(4, ItemStack.EMPTY);
     private final Container container = new Container() {
         @Override
@@ -107,6 +112,17 @@ public class InscriberBlockEntity extends BlockEntity {
         }
     };
     private final InvWrapper itemHandler = new InvWrapper(this.container);
+    private final IStorageService storageService = new IStorageService() {
+        @Override
+        public <T> IStorageChannel<T> getChannel(Class<T> type) {
+            return null;
+        }
+
+        @Override
+        public List<IStorageChannel<?>> getAllChannels() {
+            return Collections.emptyList();
+        }
+    };
 
     public InscriberBlockEntity(BlockPos pos, BlockState state) {
         super(AE2BlockEntities.INSCRIBER_BE.get(), pos, state);
@@ -118,6 +134,11 @@ public class InscriberBlockEntity extends BlockEntity {
 
     public InvWrapper getItemHandler() {
         return this.itemHandler;
+    }
+
+    @Override
+    public IStorageService getStorageService() {
+        return storageService;
     }
 
     @Override

--- a/src/main/java/appeng/capability/AE2CapabilityAttach.java
+++ b/src/main/java/appeng/capability/AE2CapabilityAttach.java
@@ -9,9 +9,11 @@ import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.event.AttachCapabilitiesEvent;
 
 import appeng.api.grid.IGridHost;
+import appeng.api.networking.IInWorldGridNodeHost;
+import appeng.api.storage.IStorageHost;
 import appeng.capability.provider.GridNodeCapabilityProvider;
 import appeng.capability.provider.InWorldGridNodeHostProvider;
-import appeng.api.networking.IInWorldGridNodeHost;
+import appeng.capability.provider.StorageServiceCapabilityProvider;
 import appeng.core.AppEng;
 
 @EventBusSubscriber(modid = AppEng.MOD_ID)
@@ -31,6 +33,9 @@ public final class AE2CapabilityAttach {
         }
         if (be instanceof IGridHost host) {
             event.addCapability(rl("grid_node"), new GridNodeCapabilityProvider(be, host));
+        }
+        if (be instanceof IStorageHost host) {
+            event.addCapability(rl("storage_service"), new StorageServiceCapabilityProvider(be, host));
         }
     }
 

--- a/src/main/java/appeng/capability/provider/StorageServiceCapabilityProvider.java
+++ b/src/main/java/appeng/capability/provider/StorageServiceCapabilityProvider.java
@@ -1,0 +1,34 @@
+package appeng.capability.provider;
+
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.neoforged.neoforge.capabilities.Capability;
+
+import appeng.AE2Capabilities;
+import appeng.api.storage.IStorageHost;
+import appeng.api.storage.IStorageService;
+
+/**
+ * Capability provider that exposes the storage service capability for AE2 block entities.
+ */
+public final class StorageServiceCapabilityProvider extends AE2BlockEntityCapabilityProvider {
+    private final IStorageHost host;
+
+    public StorageServiceCapabilityProvider(BlockEntity be, IStorageHost host) {
+        super(be);
+        this.host = host;
+    }
+
+    @Override
+    public <T> T getCapability(BlockEntity object, Capability<T> cap, @Nullable Direction side) {
+        if (cap == AE2Capabilities.STORAGE_SERVICE) {
+            IStorageService service = host.getStorageService();
+            if (service != null) {
+                return AE2Capabilities.STORAGE_SERVICE.cast(service);
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/appeng/interop/AE2Interop.java
+++ b/src/main/java/appeng/interop/AE2Interop.java
@@ -6,6 +6,7 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 
 import appeng.AE2Capabilities;
 import appeng.api.grid.IGridNode;
+import appeng.api.storage.IStorageService;
 
 /**
  * Simple helpers for third-party integrations to query AE2 grid node capabilities.
@@ -21,5 +22,14 @@ public final class AE2Interop {
     @Nullable
     public static IGridNode getGridNode(BlockEntity be) {
         return be.getCapability(AE2Capabilities.GRID_NODE, null);
+    }
+
+    public static boolean hasStorage(BlockEntity be) {
+        return getStorage(be) != null;
+    }
+
+    @Nullable
+    public static IStorageService getStorage(BlockEntity be) {
+        return be.getCapability(AE2Capabilities.STORAGE_SERVICE, null);
     }
 }

--- a/src/main/java/appeng/util/StorageHelper.java
+++ b/src/main/java/appeng/util/StorageHelper.java
@@ -1,0 +1,26 @@
+package appeng.util;
+
+import appeng.api.storage.IStorageHost;
+import appeng.api.storage.IStorageService;
+import net.minecraft.world.level.block.entity.BlockEntity;
+
+/**
+ * Utility helpers for interacting with {@link IStorageHost} implementations.
+ */
+public final class StorageHelper {
+    private StorageHelper() {
+    }
+
+    /**
+     * Attempts to retrieve the {@link IStorageService} exposed by the given block entity.
+     *
+     * @param be The block entity to query.
+     * @return The storage service if the block entity implements {@link IStorageHost}, otherwise {@code null}.
+     */
+    public static IStorageService getStorage(BlockEntity be) {
+        if (be instanceof IStorageHost host) {
+            return host.getStorageService();
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- add base storage interfaces for hosts and channels
- register a storage service capability with providers and helper utilities
- expose a placeholder storage service from the inscriber block entity

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1963c15c483278420e32c63b3d7db