### PR TITLE
Add basic item storage channel scaffolding

### DIFF
--- a/src/main/java/appeng/api/storage/IItemStorageChannel.java
+++ b/src/main/java/appeng/api/storage/IItemStorageChannel.java
@@ -1,0 +1,11 @@
+package appeng.api.storage;
+
+import net.minecraft.world.item.ItemStack;
+
+public interface IItemStorageChannel extends IStorageChannel<ItemStack> {
+    ItemStack insert(ItemStack stack, boolean simulate);
+
+    ItemStack extract(ItemStack filter, int amount, boolean simulate);
+
+    boolean contains(ItemStack filter);
+}

--- a/src/main/java/appeng/blockentity/InscriberBlockEntity.java
+++ b/src/main/java/appeng/blockentity/InscriberBlockEntity.java
@@ -1,8 +1,5 @@
 package appeng.blockentity;
 
-import java.util.Collections;
-import java.util.List;
-
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.NonNullList;
 import net.minecraft.nbt.CompoundTag;
@@ -17,12 +14,12 @@ import net.minecraft.world.level.block.state.BlockState;
 
 import net.neoforged.neoforge.items.wrapper.InvWrapper;
 
-import appeng.api.storage.IStorageChannel;
 import appeng.api.storage.IStorageHost;
 import appeng.api.storage.IStorageService;
 import appeng.registry.AE2BlockEntities;
 import appeng.recipe.AE2RecipeTypes;
 import appeng.recipe.InscriberRecipe;
+import appeng.storage.impl.StorageService;
 
 public class InscriberBlockEntity extends BlockEntity implements IStorageHost {
     private final NonNullList<ItemStack> items = NonNullList.withSize(4, ItemStack.EMPTY);
@@ -112,17 +109,7 @@ public class InscriberBlockEntity extends BlockEntity implements IStorageHost {
         }
     };
     private final InvWrapper itemHandler = new InvWrapper(this.container);
-    private final IStorageService storageService = new IStorageService() {
-        @Override
-        public <T> IStorageChannel<T> getChannel(Class<T> type) {
-            return null;
-        }
-
-        @Override
-        public List<IStorageChannel<?>> getAllChannels() {
-            return Collections.emptyList();
-        }
-    };
+    private final IStorageService storageService = new StorageService();
 
     public InscriberBlockEntity(BlockPos pos, BlockState state) {
         super(AE2BlockEntities.INSCRIBER_BE.get(), pos, state);

--- a/src/main/java/appeng/storage/impl/ItemStorageChannel.java
+++ b/src/main/java/appeng/storage/impl/ItemStorageChannel.java
@@ -1,0 +1,175 @@
+package appeng.storage.impl;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import appeng.api.storage.IItemStorageChannel;
+import net.minecraft.world.item.ItemStack;
+
+public class ItemStorageChannel implements IItemStorageChannel {
+    private final List<ItemStack> contents = new ArrayList<>();
+
+    @Override
+    public ItemStack insert(ItemStack stack, boolean simulate) {
+        if (stack.isEmpty()) {
+            return stack;
+        }
+
+        for (int i = 0; i < contents.size(); i++) {
+            var existing = contents.get(i);
+            if (ItemStack.isSameItemSameComponents(existing, stack)) {
+                int space = existing.getMaxStackSize() - existing.getCount();
+                if (space <= 0) {
+                    continue;
+                }
+
+                int toInsert = Math.min(space, stack.getCount());
+                if (toInsert > 0 && !simulate) {
+                    existing.grow(toInsert);
+                }
+                stack.shrink(toInsert);
+                if (stack.isEmpty()) {
+                    return ItemStack.EMPTY;
+                }
+            }
+        }
+
+        if (!stack.isEmpty() && !simulate) {
+            contents.add(stack.copy());
+            return ItemStack.EMPTY;
+        }
+
+        return stack;
+    }
+
+    @Override
+    public ItemStack extract(ItemStack filter, int amount, boolean simulate) {
+        if (filter.isEmpty() || amount <= 0) {
+            return ItemStack.EMPTY;
+        }
+
+        Iterator<ItemStack> iterator = contents.iterator();
+        while (iterator.hasNext()) {
+            var existing = iterator.next();
+            if (ItemStack.isSameItemSameComponents(existing, filter)) {
+                int toExtract = Math.min(existing.getCount(), amount);
+                if (toExtract <= 0) {
+                    return ItemStack.EMPTY;
+                }
+
+                ItemStack result = existing.copy();
+                result.setCount(toExtract);
+
+                if (!simulate) {
+                    existing.shrink(toExtract);
+                    if (existing.isEmpty()) {
+                        iterator.remove();
+                    }
+                }
+
+                return result;
+            }
+        }
+
+        return ItemStack.EMPTY;
+    }
+
+    @Override
+    public boolean contains(ItemStack filter) {
+        if (filter.isEmpty()) {
+            return false;
+        }
+
+        for (var stack : contents) {
+            if (ItemStack.isSameItemSameComponents(stack, filter)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public long insert(ItemStack resource, long amount, boolean simulate) {
+        if (resource.isEmpty() || amount <= 0) {
+            return 0;
+        }
+
+        long inserted = 0;
+        long remaining = amount;
+        while (remaining > 0) {
+            int attemptCount = (int) Math.min(remaining, resource.getMaxStackSize());
+            if (attemptCount <= 0) {
+                break;
+            }
+
+            ItemStack attempt = resource.copy();
+            attempt.setCount(attemptCount);
+            int before = attempt.getCount();
+            ItemStack leftover = insert(attempt, simulate);
+            int after = leftover.isEmpty() ? 0 : leftover.getCount();
+            inserted += before - after;
+            if (after > 0) {
+                break;
+            }
+            remaining -= before;
+        }
+
+        return inserted;
+    }
+
+    @Override
+    public long extract(ItemStack resource, long amount, boolean simulate) {
+        if (resource.isEmpty() || amount <= 0) {
+            return 0;
+        }
+
+        long extracted = 0;
+        long remaining = amount;
+        while (remaining > 0) {
+            int attemptAmount = (int) Math.min(remaining, resource.getMaxStackSize());
+            if (attemptAmount <= 0) {
+                break;
+            }
+
+            ItemStack result = extract(resource, attemptAmount, simulate);
+            if (result.isEmpty()) {
+                break;
+            }
+
+            extracted += result.getCount();
+            remaining -= result.getCount();
+            if (result.getCount() < attemptAmount) {
+                break;
+            }
+        }
+
+        return extracted;
+    }
+
+    @Override
+    public long getStoredAmount(ItemStack resource) {
+        if (resource.isEmpty()) {
+            return 0;
+        }
+
+        long total = 0;
+        for (var stack : contents) {
+            if (ItemStack.isSameItemSameComponents(stack, resource)) {
+                total += stack.getCount();
+            }
+        }
+        return total;
+    }
+
+    @Override
+    public Collection<ItemStack> getAll() {
+        List<ItemStack> copy = new ArrayList<>(contents.size());
+        for (var stack : contents) {
+            copy.add(stack.copy());
+        }
+        return Collections.unmodifiableList(copy);
+    }
+}

--- a/src/main/java/appeng/storage/impl/StorageService.java
+++ b/src/main/java/appeng/storage/impl/StorageService.java
@@ -1,0 +1,33 @@
+package appeng.storage.impl;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import appeng.api.storage.IItemStorageChannel;
+import appeng.api.storage.IStorageChannel;
+import appeng.api.storage.IStorageService;
+import net.minecraft.world.item.ItemStack;
+
+public class StorageService implements IStorageService {
+    private final Map<Class<?>, IStorageChannel<?>> channels = new HashMap<>();
+
+    public StorageService() {
+        channels.put(ItemStack.class, new ItemStorageChannel());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> IStorageChannel<T> getChannel(Class<T> type) {
+        return (IStorageChannel<T>) channels.get(type);
+    }
+
+    @Override
+    public List<IStorageChannel<?>> getAllChannels() {
+        return List.copyOf(channels.values());
+    }
+
+    public IItemStorageChannel getItemChannel() {
+        return (IItemStorageChannel) channels.get(ItemStack.class);
+    }
+}

--- a/src/main/java/appeng/util/StorageHelper.java
+++ b/src/main/java/appeng/util/StorageHelper.java
@@ -1,7 +1,9 @@
 package appeng.util;
 
+import appeng.api.storage.IItemStorageChannel;
 import appeng.api.storage.IStorageHost;
 import appeng.api.storage.IStorageService;
+import appeng.storage.impl.StorageService;
 import net.minecraft.world.level.block.entity.BlockEntity;
 
 /**
@@ -20,6 +22,14 @@ public final class StorageHelper {
     public static IStorageService getStorage(BlockEntity be) {
         if (be instanceof IStorageHost host) {
             return host.getStorageService();
+        }
+        return null;
+    }
+
+    public static IItemStorageChannel getItemChannel(BlockEntity be) {
+        var service = getStorage(be);
+        if (service instanceof StorageService impl) {
+            return impl.getItemChannel();
         }
         return null;
     }


### PR DESCRIPTION
## Summary
- add an IItemStorageChannel API and a simple in-memory ItemStorageChannel implementation
- register the item channel in a lightweight StorageService and expose it from the inscriber block entity
- extend StorageHelper with a convenience accessor for the new item channel

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1a00383d8832794ada5b09d8667bc