### PR TITLE
Add scaffolding for controller and energy acceptor

### DIFF
--- a/src/main/java/appeng/block/ControllerBlock.java
+++ b/src/main/java/appeng/block/ControllerBlock.java
@@ -1,0 +1,13 @@
+package appeng.block;
+
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.material.MapColor;
+
+public class ControllerBlock extends Block {
+    public ControllerBlock() {
+        super(BlockBehaviour.Properties.of()
+            .mapColor(MapColor.COLOR_PURPLE)
+            .strength(5.0f, 6.0f));
+    }
+}

--- a/src/main/java/appeng/block/EnergyAcceptorBlock.java
+++ b/src/main/java/appeng/block/EnergyAcceptorBlock.java
@@ -1,0 +1,13 @@
+package appeng.block;
+
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.material.MapColor;
+
+public class EnergyAcceptorBlock extends Block {
+    public EnergyAcceptorBlock() {
+        super(BlockBehaviour.Properties.of()
+            .mapColor(MapColor.COLOR_GRAY)
+            .strength(4.0f, 5.0f));
+    }
+}

--- a/src/main/java/appeng/blockentity/ControllerBlockEntity.java
+++ b/src/main/java/appeng/blockentity/ControllerBlockEntity.java
@@ -1,0 +1,31 @@
+package appeng.blockentity;
+
+import appeng.api.grid.IGridHost;
+import appeng.api.grid.IGridNode;
+import appeng.api.storage.IStorageHost;
+import appeng.api.storage.IStorageService;
+import appeng.registry.AE2BlockEntities;
+import appeng.storage.impl.StorageService;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+
+public class ControllerBlockEntity extends BlockEntity implements IGridHost, IStorageHost {
+    private final IGridNode gridNode = new IGridNode() {
+    };
+    private final IStorageService storageService = new StorageService();
+
+    public ControllerBlockEntity(BlockPos pos, BlockState state) {
+        super(AE2BlockEntities.CONTROLLER.get(), pos, state);
+    }
+
+    @Override
+    public IGridNode getGridNode() {
+        return gridNode;
+    }
+
+    @Override
+    public IStorageService getStorageService() {
+        return storageService;
+    }
+}

--- a/src/main/java/appeng/blockentity/EnergyAcceptorBlockEntity.java
+++ b/src/main/java/appeng/blockentity/EnergyAcceptorBlockEntity.java
@@ -1,0 +1,57 @@
+package appeng.blockentity;
+
+import appeng.registry.AE2BlockEntities;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.neoforge.energy.IEnergyStorage;
+
+public class EnergyAcceptorBlockEntity extends BlockEntity {
+    private final EnergyBuffer buffer = new EnergyBuffer();
+
+    public EnergyAcceptorBlockEntity(BlockPos pos, BlockState state) {
+        super(AE2BlockEntities.ENERGY_ACCEPTOR.get(), pos, state);
+    }
+
+    public IEnergyStorage getEnergyStorage() {
+        return buffer;
+    }
+
+    private static class EnergyBuffer implements IEnergyStorage {
+        private int energy;
+
+        @Override
+        public int receiveEnergy(int maxReceive, boolean simulate) {
+            int received = Math.min(1000 - energy, maxReceive);
+            if (!simulate) {
+                energy += received;
+            }
+            return received;
+        }
+
+        @Override
+        public int extractEnergy(int maxExtract, boolean simulate) {
+            return 0;
+        }
+
+        @Override
+        public int getEnergyStored() {
+            return energy;
+        }
+
+        @Override
+        public int getMaxEnergyStored() {
+            return 1000;
+        }
+
+        @Override
+        public boolean canExtract() {
+            return false;
+        }
+
+        @Override
+        public boolean canReceive() {
+            return true;
+        }
+    }
+}

--- a/src/main/java/appeng/datagen/AE2BlockStateProvider.java
+++ b/src/main/java/appeng/datagen/AE2BlockStateProvider.java
@@ -18,5 +18,7 @@ public class AE2BlockStateProvider extends BlockStateProvider {
         simpleBlock(AE2Blocks.INSCRIBER.get());
         simpleBlock(AE2Blocks.CHARGER.get());
         simpleBlock(AE2Blocks.SKY_STONE.get());
+        simpleBlock(AE2Blocks.CONTROLLER.get());
+        simpleBlock(AE2Blocks.ENERGY_ACCEPTOR.get());
     }
 }

--- a/src/main/java/appeng/datagen/AE2ItemModelProvider.java
+++ b/src/main/java/appeng/datagen/AE2ItemModelProvider.java
@@ -18,6 +18,8 @@ public class AE2ItemModelProvider extends ItemModelProvider {
         withExistingParent(AE2Items.CHARGER.getId().getPath(), modLoc("block/charger"));
         withExistingParent(AE2Items.CERTUS_QUARTZ_ORE.getId().getPath(), modLoc("block/certus_quartz_ore"));
         withExistingParent(AE2Items.SKY_STONE.getId().getPath(), modLoc("block/sky_stone"));
+        withExistingParent(AE2Items.CONTROLLER.getId().getPath(), modLoc("block/controller"));
+        withExistingParent(AE2Items.ENERGY_ACCEPTOR.getId().getPath(), modLoc("block/energy_acceptor"));
 
         basicItem(AE2Items.SILICON.get());
         basicItem(AE2Items.CERTUS_QUARTZ_CRYSTAL.get());

--- a/src/main/java/appeng/datagen/AE2LanguageProvider.java
+++ b/src/main/java/appeng/datagen/AE2LanguageProvider.java
@@ -16,6 +16,8 @@ public class AE2LanguageProvider extends LanguageProvider {
         add("block.appliedenergistics2.inscriber", "Inscriber");
         add("block.appliedenergistics2.charger", "Charger");
         add("block.appliedenergistics2.sky_stone", "Sky Stone");
+        add("block.appliedenergistics2.controller", "Controller");
+        add("block.appliedenergistics2.energy_acceptor", "Energy Acceptor");
 
         add("item.appliedenergistics2.silicon", "Silicon");
         add("item.appliedenergistics2.certus_quartz_crystal", "Certus Quartz Crystal");

--- a/src/main/java/appeng/init/InitCapabilityProviders.java
+++ b/src/main/java/appeng/init/InitCapabilityProviders.java
@@ -36,6 +36,7 @@ import appeng.parts.networking.EnergyAcceptorPart;
 import appeng.parts.p2p.FEP2PTunnelPart;
 import appeng.parts.p2p.FluidP2PTunnelPart;
 import appeng.parts.p2p.ItemP2PTunnelPart;
+import appeng.registry.AE2BlockEntities;
 
 public final class InitCapabilityProviders {
 
@@ -86,6 +87,10 @@ public final class InitCapabilityProviders {
             event.registerBlockEntity(AECapabilities.IN_WORLD_GRID_NODE_HOST, type,
                     (object, context) -> (IInWorldGridNodeHost) object);
         }
+
+        event.registerBlockEntity(Capabilities.EnergyStorage.BLOCK,
+                AE2BlockEntities.ENERGY_ACCEPTOR.get(),
+                (blockEntity, context) -> blockEntity.getEnergyStorage());
     }
 
     /**

--- a/src/main/java/appeng/registry/AE2BlockEntities.java
+++ b/src/main/java/appeng/registry/AE2BlockEntities.java
@@ -2,6 +2,8 @@ package appeng.registry;
 
 import appeng.AE2Registries;
 import appeng.blockentity.ChargerBlockEntity;
+import appeng.blockentity.ControllerBlockEntity;
+import appeng.blockentity.EnergyAcceptorBlockEntity;
 import appeng.blockentity.InscriberBlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.neoforged.neoforge.registries.RegistryObject;
@@ -16,6 +18,16 @@ public final class AE2BlockEntities {
         AE2Registries.BLOCK_ENTITIES.register("charger",
             () -> BlockEntityType.Builder.of(ChargerBlockEntity::new,
                 AE2Blocks.CHARGER.get()).build(null));
+
+    public static final RegistryObject<BlockEntityType<ControllerBlockEntity>> CONTROLLER =
+        AE2Registries.BLOCK_ENTITIES.register("controller",
+            () -> BlockEntityType.Builder.of(ControllerBlockEntity::new,
+                AE2Blocks.CONTROLLER.get()).build(null));
+
+    public static final RegistryObject<BlockEntityType<EnergyAcceptorBlockEntity>> ENERGY_ACCEPTOR =
+        AE2Registries.BLOCK_ENTITIES.register("energy_acceptor",
+            () -> BlockEntityType.Builder.of(EnergyAcceptorBlockEntity::new,
+                AE2Blocks.ENERGY_ACCEPTOR.get()).build(null));
 
     private AE2BlockEntities() {}
 }

--- a/src/main/java/appeng/registry/AE2Blocks.java
+++ b/src/main/java/appeng/registry/AE2Blocks.java
@@ -1,6 +1,8 @@
 package appeng.registry;
 
 import appeng.AE2Registries;
+import appeng.block.ControllerBlock;
+import appeng.block.EnergyAcceptorBlock;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockBehaviour;
@@ -27,6 +29,12 @@ public final class AE2Blocks {
         () -> new Block(BlockBehaviour.Properties.of()
             .mapColor(MapColor.COLOR_BLACK)
             .strength(50.0f, 1200.0f)));
+
+    public static final RegistryObject<Block> CONTROLLER =
+        AE2Registries.BLOCKS.register("controller", ControllerBlock::new);
+
+    public static final RegistryObject<Block> ENERGY_ACCEPTOR =
+        AE2Registries.BLOCKS.register("energy_acceptor", EnergyAcceptorBlock::new);
 
     private AE2Blocks() {}
 }

--- a/src/main/java/appeng/registry/AE2Items.java
+++ b/src/main/java/appeng/registry/AE2Items.java
@@ -79,5 +79,13 @@ public final class AE2Items {
             "sky_stone",
             () -> new BlockItem(AE2Blocks.SKY_STONE.get(), new Properties()));
 
+    public static final RegistryObject<Item> CONTROLLER = AE2Registries.ITEMS.register(
+            "controller",
+            () -> new BlockItem(AE2Blocks.CONTROLLER.get(), new Properties()));
+
+    public static final RegistryObject<Item> ENERGY_ACCEPTOR = AE2Registries.ITEMS.register(
+            "energy_acceptor",
+            () -> new BlockItem(AE2Blocks.ENERGY_ACCEPTOR.get(), new Properties()));
+
     private AE2Items() {}
 }


### PR DESCRIPTION
## Summary
- add basic controller and energy acceptor blocks and block entities as the starting point for network power handling
- register the new content with deferred registers and expose the acceptor's energy buffer through NeoForge capabilities
- extend datagen outputs to cover blockstates, item models, and language strings for the new blocks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1a9f7609c8327a30df7f0752d24ec