### PR TITLE
Add cable block scaffolding

### DIFF
--- a/src/generated/resources/assets/ae2/blockstates/cable.json
+++ b/src/generated/resources/assets/ae2/blockstates/cable.json
@@ -1,0 +1,5 @@
+{
+  "variants": {
+    "": { "model": "ae2:block/cable" }
+  }
+}

--- a/src/generated/resources/assets/ae2/lang/en_us.json
+++ b/src/generated/resources/assets/ae2/lang/en_us.json
@@ -101,6 +101,7 @@
   "block.ae2.256k_crafting_storage": "256k Crafting Storage",
   "block.ae2.4k_crafting_storage": "4k Crafting Storage",
   "block.ae2.64k_crafting_storage": "64k Crafting Storage",
+  "block.ae2.cable": "ME Cable",
   "block.ae2.cable_bus": "AE2 Cable and/or Bus",
   "block.ae2.cell_workbench": "Cell Workbench",
   "block.ae2.charger": "Charger",

--- a/src/generated/resources/assets/ae2/models/block/cable.json
+++ b/src/generated/resources/assets/ae2/models/block/cable.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:block/cube_all",
+  "textures": {
+    "all": "ae2:block/cable"
+  }
+}

--- a/src/generated/resources/assets/ae2/models/item/cable.json
+++ b/src/generated/resources/assets/ae2/models/item/cable.json
@@ -1,0 +1,3 @@
+{
+  "parent": "ae2:block/cable"
+}

--- a/src/main/java/appeng/block/CableBlock.java
+++ b/src/main/java/appeng/block/CableBlock.java
@@ -1,0 +1,24 @@
+package appeng.block;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.material.MapColor;
+
+public class CableBlock extends Block {
+    public CableBlock() {
+        super(BlockBehaviour.Properties.of()
+            .mapColor(MapColor.COLOR_BLUE)
+            .strength(1.0f));
+    }
+
+    public boolean canConnectTo(BlockGetter level, BlockPos pos, Direction dir) {
+        BlockState neighbor = level.getBlockState(pos.relative(dir));
+        return neighbor.getBlock() instanceof CableBlock
+            || neighbor.getBlock() instanceof ControllerBlock
+            || neighbor.getBlock() instanceof EnergyAcceptorBlock;
+    }
+}

--- a/src/main/java/appeng/blockentity/CableBlockEntity.java
+++ b/src/main/java/appeng/blockentity/CableBlockEntity.java
@@ -1,0 +1,21 @@
+package appeng.blockentity;
+
+import appeng.api.grid.IGridHost;
+import appeng.api.grid.IGridNode;
+import appeng.registry.AE2BlockEntities;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+
+public class CableBlockEntity extends BlockEntity implements IGridHost {
+    private final IGridNode gridNode = new IGridNode() { };
+
+    public CableBlockEntity(BlockPos pos, BlockState state) {
+        super(AE2BlockEntities.CABLE.get(), pos, state);
+    }
+
+    @Override
+    public IGridNode getGridNode() {
+        return gridNode;
+    }
+}

--- a/src/main/java/appeng/data/providers/AEBlockStateProvider.java
+++ b/src/main/java/appeng/data/providers/AEBlockStateProvider.java
@@ -5,6 +5,7 @@ import net.neoforged.neoforge.client.model.generators.BlockStateProvider;
 import net.neoforged.neoforge.common.data.ExistingFileHelper;
 
 import appeng.core.AppEng;
+import appeng.registry.AE2Blocks;
 
 public final class AEBlockStateProvider extends BlockStateProvider {
     public AEBlockStateProvider(PackOutput output, ExistingFileHelper existing) {
@@ -13,6 +14,6 @@ public final class AEBlockStateProvider extends BlockStateProvider {
 
     @Override
     protected void registerStatesAndModels() {
-        // simpleBlock(AEBlocks.QUARTZ_ORE.get());
+        simpleBlock(AE2Blocks.CABLE.get());
     }
 }

--- a/src/main/java/appeng/data/providers/AEItemModelProvider.java
+++ b/src/main/java/appeng/data/providers/AEItemModelProvider.java
@@ -5,6 +5,7 @@ import net.neoforged.neoforge.client.model.generators.ItemModelProvider;
 import net.neoforged.neoforge.common.data.ExistingFileHelper;
 
 import appeng.core.AppEng;
+import appeng.registry.AE2Blocks;
 
 public final class AEItemModelProvider extends ItemModelProvider {
     public AEItemModelProvider(PackOutput output, ExistingFileHelper existing) {
@@ -13,7 +14,6 @@ public final class AEItemModelProvider extends ItemModelProvider {
 
     @Override
     protected void registerModels() {
-        // withExistingParent(AEItems.SOMETHING.getId().getPath(), modLoc("item/generated"))
-        //     .texture("layer0", modLoc("item/something"));
+        withExistingParent(AE2Blocks.CABLE.getId().getPath(), modLoc("block/cable"));
     }
 }

--- a/src/main/java/appeng/data/providers/AELangProvider.java
+++ b/src/main/java/appeng/data/providers/AELangProvider.java
@@ -12,6 +12,6 @@ public final class AELangProvider extends LanguageProvider {
 
     @Override
     protected void addTranslations() {
-        // add("item." + AppEng.MOD_ID + ".certus_quartz", "Certus Quartz");
+        add("block." + AppEng.MOD_ID + ".cable", "ME Cable");
     }
 }

--- a/src/main/java/appeng/registry/AE2BlockEntities.java
+++ b/src/main/java/appeng/registry/AE2BlockEntities.java
@@ -1,6 +1,7 @@
 package appeng.registry;
 
 import appeng.AE2Registries;
+import appeng.blockentity.CableBlockEntity;
 import appeng.blockentity.ChargerBlockEntity;
 import appeng.blockentity.ControllerBlockEntity;
 import appeng.blockentity.EnergyAcceptorBlockEntity;
@@ -28,6 +29,10 @@ public final class AE2BlockEntities {
         AE2Registries.BLOCK_ENTITIES.register("energy_acceptor",
             () -> BlockEntityType.Builder.of(EnergyAcceptorBlockEntity::new,
                 AE2Blocks.ENERGY_ACCEPTOR.get()).build(null));
+
+    public static final RegistryObject<BlockEntityType<CableBlockEntity>> CABLE =
+        AE2Registries.BLOCK_ENTITIES.register("cable",
+            () -> BlockEntityType.Builder.of(CableBlockEntity::new, AE2Blocks.CABLE.get()).build(null));
 
     private AE2BlockEntities() {}
 }

--- a/src/main/java/appeng/registry/AE2Blocks.java
+++ b/src/main/java/appeng/registry/AE2Blocks.java
@@ -1,6 +1,7 @@
 package appeng.registry;
 
 import appeng.AE2Registries;
+import appeng.block.CableBlock;
 import appeng.block.ControllerBlock;
 import appeng.block.EnergyAcceptorBlock;
 import net.minecraft.world.level.block.Block;
@@ -35,6 +36,9 @@ public final class AE2Blocks {
 
     public static final RegistryObject<Block> ENERGY_ACCEPTOR =
         AE2Registries.BLOCKS.register("energy_acceptor", EnergyAcceptorBlock::new);
+
+    public static final RegistryObject<Block> CABLE =
+        AE2Registries.BLOCKS.register("cable", CableBlock::new);
 
     private AE2Blocks() {}
 }

--- a/src/main/java/appeng/registry/AE2Items.java
+++ b/src/main/java/appeng/registry/AE2Items.java
@@ -87,5 +87,9 @@ public final class AE2Items {
             "energy_acceptor",
             () -> new BlockItem(AE2Blocks.ENERGY_ACCEPTOR.get(), new Properties()));
 
+    public static final RegistryObject<Item> CABLE = AE2Registries.ITEMS.register(
+            "cable",
+            () -> new BlockItem(AE2Blocks.CABLE.get(), new Properties()));
+
     private AE2Items() {}
 }


### PR DESCRIPTION
## Summary
- add a basic Cable block with simple connection checks and a companion block entity exposing an `IGridNode`
- register the cable block, its block entity type, and an item entry with the existing deferred registers
- add generated resources for the cable blockstate, models, and localisation along with datagen hooks

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1b5017b208327ae69cdeb0356bbcb