### PR TITLE
Implement basic grid node discovery for simple block entities

### DIFF
--- a/src/main/java/appeng/api/grid/IGridNode.java
+++ b/src/main/java/appeng/api/grid/IGridNode.java
@@ -1,8 +1,12 @@
 package appeng.api.grid;
 
+import java.util.Set;
+
 /**
- * Placeholder grid node interface for future capability-based integration.
+ * Basic grid node abstraction used to connect blocks into a graph.
  */
 public interface IGridNode {
-    // TODO: Add network management functions
+    void connect(IGridNode other);
+
+    Set<IGridNode> neighbors();
 }

--- a/src/main/java/appeng/blockentity/CableBlockEntity.java
+++ b/src/main/java/appeng/blockentity/CableBlockEntity.java
@@ -2,13 +2,15 @@ package appeng.blockentity;
 
 import appeng.api.grid.IGridHost;
 import appeng.api.grid.IGridNode;
+import appeng.grid.SimpleGridNode;
 import appeng.registry.AE2BlockEntities;
+import appeng.util.GridHelper;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 
 public class CableBlockEntity extends BlockEntity implements IGridHost {
-    private final IGridNode gridNode = new IGridNode() { };
+    private final IGridNode gridNode = new SimpleGridNode();
 
     public CableBlockEntity(BlockPos pos, BlockState state) {
         super(AE2BlockEntities.CABLE.get(), pos, state);
@@ -17,5 +19,17 @@ public class CableBlockEntity extends BlockEntity implements IGridHost {
     @Override
     public IGridNode getGridNode() {
         return gridNode;
+    }
+
+    @Override
+    public void onLoad() {
+        super.onLoad();
+        GridHelper.discover(this);
+    }
+
+    @Override
+    public void setRemoved() {
+        super.setRemoved();
+        // TODO: Prune connections when nodes are removed
     }
 }

--- a/src/main/java/appeng/blockentity/ChargerBlockEntity.java
+++ b/src/main/java/appeng/blockentity/ChargerBlockEntity.java
@@ -14,14 +14,18 @@ import net.minecraft.world.level.block.state.BlockState;
 
 import net.neoforged.neoforge.items.wrapper.InvWrapper;
 
+import appeng.api.grid.IGridHost;
+import appeng.api.grid.IGridNode;
 import appeng.api.storage.IStorageHost;
 import appeng.api.storage.IStorageService;
+import appeng.grid.SimpleGridNode;
 import appeng.registry.AE2BlockEntities;
 import appeng.recipe.AE2RecipeTypes;
 import appeng.recipe.ChargerRecipe;
 import appeng.storage.impl.StorageService;
+import appeng.util.GridHelper;
 
-public class ChargerBlockEntity extends BlockEntity implements IStorageHost {
+public class ChargerBlockEntity extends BlockEntity implements IStorageHost, IGridHost {
     private final NonNullList<ItemStack> items = NonNullList.withSize(2, ItemStack.EMPTY);
     private final Container container = new Container() {
         @Override
@@ -109,6 +113,7 @@ public class ChargerBlockEntity extends BlockEntity implements IStorageHost {
         }
     };
     private final InvWrapper itemHandler = new InvWrapper(this.container);
+    private final IGridNode gridNode = new SimpleGridNode();
     private final IStorageService storageService = new StorageService();
 
     private int chargeTime = 0;
@@ -117,12 +122,29 @@ public class ChargerBlockEntity extends BlockEntity implements IStorageHost {
         super(AE2BlockEntities.CHARGER_BE.get(), pos, state);
     }
 
+    @Override
+    public void onLoad() {
+        super.onLoad();
+        GridHelper.discover(this);
+    }
+
+    @Override
+    public void setRemoved() {
+        super.setRemoved();
+        // TODO: Prune connections when nodes are removed
+    }
+
     public NonNullList<ItemStack> getItems() {
         return items;
     }
 
     public InvWrapper getItemHandler() {
         return this.itemHandler;
+    }
+
+    @Override
+    public IGridNode getGridNode() {
+        return gridNode;
     }
 
     @Override

--- a/src/main/java/appeng/blockentity/ControllerBlockEntity.java
+++ b/src/main/java/appeng/blockentity/ControllerBlockEntity.java
@@ -6,13 +6,14 @@ import appeng.api.storage.IStorageHost;
 import appeng.api.storage.IStorageService;
 import appeng.registry.AE2BlockEntities;
 import appeng.storage.impl.StorageService;
+import appeng.grid.SimpleGridNode;
+import appeng.util.GridHelper;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 
 public class ControllerBlockEntity extends BlockEntity implements IGridHost, IStorageHost {
-    private final IGridNode gridNode = new IGridNode() {
-    };
+    private final IGridNode gridNode = new SimpleGridNode();
     private final IStorageService storageService = new StorageService();
 
     public ControllerBlockEntity(BlockPos pos, BlockState state) {
@@ -22,6 +23,18 @@ public class ControllerBlockEntity extends BlockEntity implements IGridHost, ISt
     @Override
     public IGridNode getGridNode() {
         return gridNode;
+    }
+
+    @Override
+    public void onLoad() {
+        super.onLoad();
+        GridHelper.discover(this);
+    }
+
+    @Override
+    public void setRemoved() {
+        super.setRemoved();
+        // TODO: Prune connections when nodes are removed
     }
 
     @Override

--- a/src/main/java/appeng/blockentity/EnergyAcceptorBlockEntity.java
+++ b/src/main/java/appeng/blockentity/EnergyAcceptorBlockEntity.java
@@ -1,16 +1,38 @@
 package appeng.blockentity;
 
+import appeng.api.grid.IGridHost;
+import appeng.api.grid.IGridNode;
+import appeng.grid.SimpleGridNode;
 import appeng.registry.AE2BlockEntities;
+import appeng.util.GridHelper;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.neoforge.energy.IEnergyStorage;
 
-public class EnergyAcceptorBlockEntity extends BlockEntity {
+public class EnergyAcceptorBlockEntity extends BlockEntity implements IGridHost {
+    private final IGridNode gridNode = new SimpleGridNode();
     private final EnergyBuffer buffer = new EnergyBuffer();
 
     public EnergyAcceptorBlockEntity(BlockPos pos, BlockState state) {
         super(AE2BlockEntities.ENERGY_ACCEPTOR.get(), pos, state);
+    }
+
+    @Override
+    public void onLoad() {
+        super.onLoad();
+        GridHelper.discover(this);
+    }
+
+    @Override
+    public void setRemoved() {
+        super.setRemoved();
+        // TODO: Prune connections when nodes are removed
+    }
+
+    @Override
+    public IGridNode getGridNode() {
+        return gridNode;
     }
 
     public IEnergyStorage getEnergyStorage() {

--- a/src/main/java/appeng/blockentity/InscriberBlockEntity.java
+++ b/src/main/java/appeng/blockentity/InscriberBlockEntity.java
@@ -14,14 +14,18 @@ import net.minecraft.world.level.block.state.BlockState;
 
 import net.neoforged.neoforge.items.wrapper.InvWrapper;
 
+import appeng.api.grid.IGridHost;
+import appeng.api.grid.IGridNode;
 import appeng.api.storage.IStorageHost;
 import appeng.api.storage.IStorageService;
+import appeng.grid.SimpleGridNode;
 import appeng.registry.AE2BlockEntities;
 import appeng.recipe.AE2RecipeTypes;
 import appeng.recipe.InscriberRecipe;
 import appeng.storage.impl.StorageService;
+import appeng.util.GridHelper;
 
-public class InscriberBlockEntity extends BlockEntity implements IStorageHost {
+public class InscriberBlockEntity extends BlockEntity implements IStorageHost, IGridHost {
     private final NonNullList<ItemStack> items = NonNullList.withSize(4, ItemStack.EMPTY);
     private final Container container = new Container() {
         @Override
@@ -109,10 +113,23 @@ public class InscriberBlockEntity extends BlockEntity implements IStorageHost {
         }
     };
     private final InvWrapper itemHandler = new InvWrapper(this.container);
+    private final IGridNode gridNode = new SimpleGridNode();
     private final IStorageService storageService = new StorageService();
 
     public InscriberBlockEntity(BlockPos pos, BlockState state) {
         super(AE2BlockEntities.INSCRIBER_BE.get(), pos, state);
+    }
+
+    @Override
+    public void onLoad() {
+        super.onLoad();
+        GridHelper.discover(this);
+    }
+
+    @Override
+    public void setRemoved() {
+        super.setRemoved();
+        // TODO: Prune connections when nodes are removed
     }
 
     public NonNullList<ItemStack> getItems() {
@@ -121,6 +138,11 @@ public class InscriberBlockEntity extends BlockEntity implements IStorageHost {
 
     public InvWrapper getItemHandler() {
         return this.itemHandler;
+    }
+
+    @Override
+    public IGridNode getGridNode() {
+        return gridNode;
     }
 
     @Override

--- a/src/main/java/appeng/blockentity/misc/ChargerBlockEntity.java
+++ b/src/main/java/appeng/blockentity/misc/ChargerBlockEntity.java
@@ -52,6 +52,7 @@ import appeng.core.settings.TickRates;
 import appeng.util.Platform;
 import appeng.util.inv.AppEngInternalInventory;
 import appeng.util.inv.filter.IAEItemFilter;
+import appeng.grid.SimpleGridNode;
 
 public class ChargerBlockEntity extends AENetworkedPoweredBlockEntity implements IGridTickable, IGridHost {
     public static final int POWER_MAXIMUM_AMOUNT = 1600;
@@ -59,9 +60,7 @@ public class ChargerBlockEntity extends AENetworkedPoweredBlockEntity implements
     private boolean working;
 
     private final AppEngInternalInventory inv = new AppEngInternalInventory(this, 1, 1, new ChargerInvFilter(this));
-    private final appeng.api.grid.IGridNode gridNode = new appeng.api.grid.IGridNode() {
-        // TODO: Hook up real grid node once capability is fully implemented.
-    };
+    private final appeng.api.grid.IGridNode gridNode = new SimpleGridNode();
 
     public ChargerBlockEntity(BlockEntityType<?> blockEntityType, BlockPos pos, BlockState blockState) {
         super(blockEntityType, pos, blockState);

--- a/src/main/java/appeng/blockentity/misc/InscriberBlockEntity.java
+++ b/src/main/java/appeng/blockentity/misc/InscriberBlockEntity.java
@@ -71,6 +71,7 @@ import appeng.util.inv.AppEngInternalInventory;
 import appeng.util.inv.CombinedInternalInventory;
 import appeng.util.inv.FilteredInternalInventory;
 import appeng.util.inv.filter.IAEItemFilter;
+import appeng.grid.SimpleGridNode;
 
 /**
  * @author AlgorithmX2
@@ -95,9 +96,7 @@ public class InscriberBlockEntity extends AENetworkedPoweredBlockEntity
     private int finalStep;
     private long clientStart;
 
-    private final appeng.api.grid.IGridNode gridNode = new appeng.api.grid.IGridNode() {
-        // TODO: Hook up real grid node once capability is fully implemented.
-    };
+    private final appeng.api.grid.IGridNode gridNode = new SimpleGridNode();
 
     // Internally visible inventories
     private final IAEItemFilter baseFilter = new BaseFilter();

--- a/src/main/java/appeng/grid/SimpleGridNode.java
+++ b/src/main/java/appeng/grid/SimpleGridNode.java
@@ -1,0 +1,24 @@
+package appeng.grid;
+
+import appeng.api.grid.IGridNode;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Simple in-memory grid node implementation.
+ */
+public class SimpleGridNode implements IGridNode {
+    private final Set<IGridNode> neighbors = new HashSet<>();
+
+    @Override
+    public void connect(IGridNode other) {
+        if (other != null && other != this) {
+            neighbors.add(other);
+        }
+    }
+
+    @Override
+    public Set<IGridNode> neighbors() {
+        return Set.copyOf(neighbors);
+    }
+}

--- a/src/main/java/appeng/util/GridHelper.java
+++ b/src/main/java/appeng/util/GridHelper.java
@@ -1,24 +1,41 @@
 package appeng.util;
 
-import org.jetbrains.annotations.Nullable;
-
-import net.minecraft.world.level.block.entity.BlockEntity;
-
 import appeng.api.grid.IGridHost;
 import appeng.api.grid.IGridNode;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
 
-/**
- * Utility helpers for working with grid-hosting block entities via capabilities.
- */
 public final class GridHelper {
     private GridHelper() {
     }
 
-    @Nullable
-    public static IGridNode getNode(BlockEntity be) {
-        if (be instanceof IGridHost host) {
-            return host.getGridNode();
+    public static void discover(BlockEntity be) {
+        if (!(be instanceof IGridHost host)) {
+            return;
         }
-        return null;
+
+        IGridNode self = host.getGridNode();
+        if (self == null) {
+            return;
+        }
+
+        Level level = be.getLevel();
+        if (level == null || level.isClientSide()) {
+            return;
+        }
+
+        BlockPos pos = be.getBlockPos();
+        for (Direction dir : Direction.values()) {
+            BlockEntity neighbor = level.getBlockEntity(pos.relative(dir));
+            if (neighbor instanceof IGridHost nHost) {
+                IGridNode neighborNode = nHost.getGridNode();
+                if (neighborNode != null) {
+                    self.connect(neighborNode);
+                    neighborNode.connect(self);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- expand the grid node API with connection and neighbor accessors and provide a simple in-memory implementation
- have controller, cable, energy acceptor, inscriber, and charger block entities expose SimpleGridNode instances and trigger discovery
- add a grid discovery helper that links adjacent hosts and update existing networked machines to use the new node implementation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1b76a39d88327b52a0b1737b9c74b