### PR TITLE
Add grid set tracking with controller awareness

### DIFF
--- a/src/main/java/appeng/api/grid/IGridNode.java
+++ b/src/main/java/appeng/api/grid/IGridNode.java
@@ -1,6 +1,7 @@
 package appeng.api.grid;
 
 import java.util.Set;
+import java.util.UUID;
 
 /**
  * Basic grid node abstraction used to connect blocks into a graph.
@@ -9,4 +10,6 @@ public interface IGridNode {
     void connect(IGridNode other);
 
     Set<IGridNode> neighbors();
+
+    UUID getGridId();
 }

--- a/src/main/java/appeng/grid/GridId.java
+++ b/src/main/java/appeng/grid/GridId.java
@@ -1,0 +1,9 @@
+package appeng.grid;
+
+import java.util.UUID;
+
+public record GridId(UUID id) {
+    public static GridId random() {
+        return new GridId(UUID.randomUUID());
+    }
+}

--- a/src/main/java/appeng/grid/GridIndex.java
+++ b/src/main/java/appeng/grid/GridIndex.java
@@ -1,0 +1,39 @@
+package appeng.grid;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.jetbrains.annotations.Nullable;
+
+public final class GridIndex {
+    private static final GridIndex INSTANCE = new GridIndex();
+
+    public static GridIndex get() {
+        return INSTANCE;
+    }
+
+    private final Map<UUID, GridSet> sets = new ConcurrentHashMap<>();
+
+    public GridSet getOrCreate(UUID id) {
+        return sets.computeIfAbsent(id, k -> new GridSet(new GridId(k)));
+    }
+
+    @Nullable
+    public GridSet get(UUID id) {
+        return sets.get(id);
+    }
+
+    public Collection<GridSet> all() {
+        return sets.values();
+    }
+
+    public void drop(UUID id) {
+        sets.remove(id);
+    }
+
+    public void clear() {
+        sets.clear();
+    }
+}

--- a/src/main/java/appeng/grid/GridSet.java
+++ b/src/main/java/appeng/grid/GridSet.java
@@ -1,0 +1,59 @@
+package appeng.grid;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import appeng.api.grid.IGridNode;
+
+public final class GridSet {
+    private final GridId id;
+    private final Set<IGridNode> nodes = ConcurrentHashMap.newKeySet();
+    private volatile boolean hasController;
+    private volatile boolean online;
+    private volatile long energyBudget;
+
+    public GridSet(GridId id) {
+        this.id = id;
+    }
+
+    public GridId id() {
+        return id;
+    }
+
+    public void add(IGridNode n) {
+        nodes.add(n);
+    }
+
+    public void remove(IGridNode n) {
+        nodes.remove(n);
+    }
+
+    public Set<IGridNode> nodes() {
+        return Collections.unmodifiableSet(nodes);
+    }
+
+    public boolean hasController() {
+        return hasController;
+    }
+
+    public void setHasController(boolean v) {
+        hasController = v;
+    }
+
+    public boolean isOnline() {
+        return online;
+    }
+
+    public void setOnline(boolean v) {
+        online = v;
+    }
+
+    public long energyBudget() {
+        return energyBudget;
+    }
+
+    public void setEnergyBudget(long b) {
+        energyBudget = b;
+    }
+}

--- a/src/main/java/appeng/grid/SimpleGridNode.java
+++ b/src/main/java/appeng/grid/SimpleGridNode.java
@@ -1,24 +1,66 @@
 package appeng.grid;
 
-import appeng.api.grid.IGridNode;
-import java.util.HashSet;
+import java.util.Collections;
+import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import appeng.api.grid.IGridNode;
 
 /**
  * Simple in-memory grid node implementation.
  */
 public class SimpleGridNode implements IGridNode {
-    private final Set<IGridNode> neighbors = new HashSet<>();
+    private final Set<IGridNode> neighbors = ConcurrentHashMap.newKeySet();
+    private UUID gridId = GridId.random().id();
+
+    public SimpleGridNode() {
+        GridIndex.get().getOrCreate(gridId).add(this);
+    }
 
     @Override
     public void connect(IGridNode other) {
-        if (other != null && other != this) {
-            neighbors.add(other);
+        if (other == null || other == this) {
+            return;
+        }
+
+        neighbors.add(other);
+
+        var otherId = other.getGridId();
+        if (otherId != null && !Objects.equals(this.gridId, otherId)) {
+            moveToGrid(otherId);
+        }
+    }
+
+    private void moveToGrid(UUID newId) {
+        if (newId == null || Objects.equals(this.gridId, newId)) {
+            return;
+        }
+
+        var index = GridIndex.get();
+        var oldId = this.gridId;
+        this.gridId = newId;
+        index.getOrCreate(newId).add(this);
+
+        if (oldId != null && !Objects.equals(oldId, newId)) {
+            var oldSet = index.get(oldId);
+            if (oldSet != null) {
+                oldSet.remove(this);
+                if (oldSet.nodes().isEmpty()) {
+                    index.drop(oldId);
+                }
+            }
         }
     }
 
     @Override
     public Set<IGridNode> neighbors() {
-        return Set.copyOf(neighbors);
+        return Collections.unmodifiableSet(neighbors);
+    }
+
+    @Override
+    public UUID getGridId() {
+        return gridId;
     }
 }

--- a/src/main/java/appeng/util/GridHelper.java
+++ b/src/main/java/appeng/util/GridHelper.java
@@ -1,13 +1,27 @@
 package appeng.util;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.WeakHashMap;
+
 import appeng.api.grid.IGridHost;
 import appeng.api.grid.IGridNode;
+import appeng.blockentity.ControllerBlockEntity;
+import appeng.core.AELog;
+import appeng.grid.GridIndex;
+import appeng.grid.GridSet;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 
 public final class GridHelper {
+    private static final Map<IGridNode, BlockEntity> HOSTS = Collections.synchronizedMap(new WeakHashMap<>());
+
     private GridHelper() {
     }
 
@@ -21,10 +35,16 @@ public final class GridHelper {
             return;
         }
 
+        HOSTS.put(self, be);
+        GridIndex.get().getOrCreate(self.getGridId()).add(self);
+
         Level level = be.getLevel();
         if (level == null || level.isClientSide()) {
             return;
         }
+
+        Set<UUID> touched = new HashSet<>();
+        touched.add(self.getGridId());
 
         BlockPos pos = be.getBlockPos();
         for (Direction dir : Direction.values()) {
@@ -32,10 +52,46 @@ public final class GridHelper {
             if (neighbor instanceof IGridHost nHost) {
                 IGridNode neighborNode = nHost.getGridNode();
                 if (neighborNode != null) {
-                    self.connect(neighborNode);
-                    neighborNode.connect(self);
+                    HOSTS.putIfAbsent(neighborNode, neighbor);
+                    merge(self, neighborNode);
+                    touched.add(self.getGridId());
+                    touched.add(neighborNode.getGridId());
                 }
             }
         }
+
+        for (UUID id : touched) {
+            updateSetMetadata(id);
+        }
+    }
+
+    private static void merge(IGridNode a, IGridNode b) {
+        a.connect(b);
+        b.connect(a);
+
+        GridIndex index = GridIndex.get();
+        index.getOrCreate(a.getGridId()).add(a);
+        index.getOrCreate(b.getGridId()).add(b);
+    }
+
+    private static void updateSetMetadata(UUID gridId) {
+        GridSet set = GridIndex.get().get(gridId);
+        if (set == null) {
+            return;
+        }
+
+        boolean hasController = set.nodes().stream()
+                .map(HOSTS::get)
+                .filter(Objects::nonNull)
+                .anyMatch(GridHelper::isController);
+
+        set.setHasController(hasController);
+        set.setOnline(hasController);
+
+        AELog.debug("GridSet {} size={} hasController={}", gridId, set.nodes().size(), hasController);
+    }
+
+    private static boolean isController(Object be) {
+        return be instanceof ControllerBlockEntity;
     }
 }


### PR DESCRIPTION
## Summary
- add GridId, GridSet, and GridIndex to model connected network sets
- propagate stable grid ids through SimpleGridNode connections and discovery
- record controller presence per grid set with debug logging

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e1be914b38832796e3b94fe3230be0