### PR TITLE
Add drive bay storage integration and basic 1k cell

### DIFF
--- a/src/main/java/appeng/api/storage/IItemStorageChannel.java
+++ b/src/main/java/appeng/api/storage/IItemStorageChannel.java
@@ -2,10 +2,14 @@ package appeng.api.storage;
 
 import net.minecraft.world.item.ItemStack;
 
+import appeng.api.storage.ItemStackView;
+
 public interface IItemStorageChannel extends IStorageChannel<ItemStack> {
     ItemStack insert(ItemStack stack, boolean simulate);
 
     ItemStack extract(ItemStack filter, int amount, boolean simulate);
 
     boolean contains(ItemStack filter);
+
+    Iterable<ItemStackView> getAll();
 }

--- a/src/main/java/appeng/api/storage/IStorageChannel.java
+++ b/src/main/java/appeng/api/storage/IStorageChannel.java
@@ -1,7 +1,5 @@
 package appeng.api.storage;
 
-import java.util.Collection;
-
 /**
  * Represents a storage channel capable of storing, extracting and querying a specific type of
  * resource.
@@ -37,10 +35,4 @@ public interface IStorageChannel<T> {
      */
     long getStoredAmount(T resource);
 
-    /**
-     * Gets a collection of all resources currently stored in this channel.
-     *
-     * @return The resources currently available in this channel.
-     */
-    Collection<T> getAll();
 }

--- a/src/main/java/appeng/api/storage/ItemStackView.java
+++ b/src/main/java/appeng/api/storage/ItemStackView.java
@@ -1,0 +1,12 @@
+package appeng.api.storage;
+
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+
+public record ItemStackView(Item item, int count) {
+    public ItemStack asStack() {
+        ItemStack stack = new ItemStack(item);
+        stack.setCount(count);
+        return stack;
+    }
+}

--- a/src/main/java/appeng/block/simple/DriveBlock.java
+++ b/src/main/java/appeng/block/simple/DriveBlock.java
@@ -1,0 +1,25 @@
+package appeng.block.simple;
+
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.EntityBlock;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.material.MapColor;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.core.BlockPos;
+
+import org.jetbrains.annotations.Nullable;
+
+import appeng.blockentity.simple.DriveBlockEntity;
+
+public class DriveBlock extends Block implements EntityBlock {
+    public DriveBlock() {
+        super(BlockBehaviour.Properties.of().mapColor(MapColor.METAL).strength(4.0f, 6.0f));
+    }
+
+    @Nullable
+    @Override
+    public BlockEntity newBlockEntity(BlockPos pos, BlockState state) {
+        return new DriveBlockEntity(pos, state);
+    }
+}

--- a/src/main/java/appeng/blockentity/simple/DriveBlockEntity.java
+++ b/src/main/java/appeng/blockentity/simple/DriveBlockEntity.java
@@ -1,0 +1,212 @@
+package appeng.blockentity.simple;
+
+import java.util.UUID;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.NonNullList;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.Container;
+import net.minecraft.world.ContainerHelper;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+
+import net.neoforged.neoforge.items.wrapper.InvWrapper;
+
+import appeng.api.grid.IGridHost;
+import appeng.api.grid.IGridNode;
+import appeng.items.storage.BasicCell1kItem;
+import appeng.grid.NodeType;
+import appeng.grid.SimpleGridNode;
+import appeng.registry.AE2BlockEntities;
+import appeng.storage.impl.StorageService;
+import appeng.util.GridHelper;
+
+public class DriveBlockEntity extends BlockEntity implements IGridHost {
+    private static final int SLOT_COUNT = 4;
+
+    private final NonNullList<ItemStack> cells = NonNullList.withSize(SLOT_COUNT, ItemStack.EMPTY);
+    private final Container container = new Container() {
+        @Override
+        public int getContainerSize() {
+            return SLOT_COUNT;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            for (var stack : cells) {
+                if (!stack.isEmpty()) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public ItemStack getItem(int index) {
+            return cells.get(index);
+        }
+
+        @Override
+        public ItemStack removeItem(int index, int count) {
+            ItemStack removed = ContainerHelper.removeItem(cells, index, count);
+            if (!removed.isEmpty()) {
+                onCellsChanged();
+            }
+            return removed;
+        }
+
+        @Override
+        public ItemStack removeItemNoUpdate(int index) {
+            ItemStack stack = cells.get(index);
+            if (stack.isEmpty()) {
+                return ItemStack.EMPTY;
+            }
+            cells.set(index, ItemStack.EMPTY);
+            onCellsChanged();
+            return stack;
+        }
+
+        @Override
+        public void setItem(int index, ItemStack stack) {
+            cells.set(index, stack);
+            if (!stack.isEmpty() && stack.getCount() > getMaxStackSize()) {
+                stack.setCount(getMaxStackSize());
+            }
+            onCellsChanged();
+        }
+
+        @Override
+        public int getMaxStackSize() {
+            return 1;
+        }
+
+        @Override
+        public void setChanged() {
+            DriveBlockEntity.this.setChanged();
+        }
+
+        @Override
+        public boolean stillValid(Player player) {
+            return true;
+        }
+
+        @Override
+        public void clearContent() {
+            for (int i = 0; i < SLOT_COUNT; i++) {
+                cells.set(i, ItemStack.EMPTY);
+            }
+            onCellsChanged();
+        }
+
+        @Override
+        public void startOpen(Player player) {
+        }
+
+        @Override
+        public void stopOpen(Player player) {
+        }
+
+        @Override
+        public boolean canPlaceItem(int index, ItemStack stack) {
+            return stack.isEmpty() || stack.getItem() instanceof BasicCell1kItem;
+        }
+    };
+    private final InvWrapper itemHandler = new InvWrapper(container);
+    private final SimpleGridNode gridNode = new SimpleGridNode(NodeType.MACHINE);
+    private UUID mountedGridId;
+
+    public DriveBlockEntity(BlockPos pos, BlockState state) {
+        super(AE2BlockEntities.DRIVE_SIMPLE.get(), pos, state);
+    }
+
+    @Override
+    public void onLoad() {
+        super.onLoad();
+        GridHelper.discover(this);
+        ensureMounted();
+    }
+
+    @Override
+    public void setRemoved() {
+        super.setRemoved();
+        if (mountedGridId != null) {
+            StorageService.unmountDrive(mountedGridId, this);
+            GridHelper.updateSetMetadata(mountedGridId);
+            mountedGridId = null;
+        }
+    }
+
+    private void onCellsChanged() {
+        setChanged();
+        ensureMounted();
+    }
+
+    public NonNullList<ItemStack> getCells() {
+        return cells;
+    }
+
+    public InvWrapper getItemHandler() {
+        return itemHandler;
+    }
+
+    @Override
+    public IGridNode getGridNode() {
+        return gridNode;
+    }
+
+    @Override
+    public void load(CompoundTag tag) {
+        super.load(tag);
+        ContainerHelper.loadAllItems(tag, cells);
+    }
+
+    @Override
+    protected void saveAdditional(CompoundTag tag) {
+        super.saveAdditional(tag);
+        ContainerHelper.saveAllItems(tag, cells);
+    }
+
+    public int getCellSlotCount() {
+        return SLOT_COUNT;
+    }
+
+    public ItemStack getCellInSlot(int slot) {
+        return cells.get(slot);
+    }
+
+    public void notifyGridChanged() {
+        ensureMounted();
+    }
+
+    private void ensureMounted() {
+        Level level = getLevel();
+        if (level == null || level.isClientSide()) {
+            return;
+        }
+
+        UUID grid = gridNode.getGridId();
+        if (grid == null) {
+            if (mountedGridId != null) {
+                StorageService.unmountDrive(mountedGridId, this);
+                GridHelper.updateSetMetadata(mountedGridId);
+                mountedGridId = null;
+            }
+            return;
+        }
+
+        if (!grid.equals(mountedGridId)) {
+            if (mountedGridId != null) {
+                StorageService.unmountDrive(mountedGridId, this);
+            }
+            mountedGridId = grid;
+            StorageService.mountDrive(grid, this);
+        } else {
+            StorageService.refreshDrive(grid, this);
+        }
+
+        GridHelper.updateSetMetadata(grid);
+    }
+}

--- a/src/main/java/appeng/grid/GridSet.java
+++ b/src/main/java/appeng/grid/GridSet.java
@@ -13,6 +13,8 @@ public final class GridSet {
     private volatile boolean online;
     private volatile long energyBudget;
     private volatile long tickCost;
+    private volatile long itemCellCapacity;
+    private volatile long itemCellUsage;
 
     public GridSet(GridId id) {
         this.id = id;
@@ -71,5 +73,21 @@ public final class GridSet {
         boolean changed = newOnline != this.online;
         this.online = newOnline;
         return changed;
+    }
+
+    public long itemCellCapacity() {
+        return itemCellCapacity;
+    }
+
+    public void setItemCellCapacity(long capacity) {
+        this.itemCellCapacity = capacity;
+    }
+
+    public long itemCellUsage() {
+        return itemCellUsage;
+    }
+
+    public void setItemCellUsage(long usage) {
+        this.itemCellUsage = usage;
     }
 }

--- a/src/main/java/appeng/items/storage/BasicCell1kItem.java
+++ b/src/main/java/appeng/items/storage/BasicCell1kItem.java
@@ -1,0 +1,209 @@
+package appeng.items.storage;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+
+import appeng.api.storage.ItemStackView;
+import appeng.api.storage.cells.IBasicCellItem;
+import appeng.api.stacks.AEKeyType;
+import appeng.items.AEBaseItem;
+
+public class BasicCell1kItem extends AEBaseItem implements IBasicCellItem {
+    private static final String CELL_TAG = "CellData";
+    private static final String ITEMS_TAG = "Items";
+    private static final int CAPACITY = 1024;
+
+    public BasicCell1kItem(Properties properties) {
+        super(properties);
+    }
+
+    @Override
+    public AEKeyType getKeyType() {
+        return AEKeyType.items();
+    }
+
+    @Override
+    public int getBytes(ItemStack cellItem) {
+        return CAPACITY;
+    }
+
+    @Override
+    public int getBytesPerType(ItemStack cellItem) {
+        return 1;
+    }
+
+    @Override
+    public int getTotalTypes(ItemStack cellItem) {
+        return 63;
+    }
+
+    @Override
+    public double getIdleDrain() {
+        return 1.0;
+    }
+
+    public int getRemainingCapacity(ItemStack cell) {
+        return CAPACITY - getTotalStored(cell);
+    }
+
+    public int getTotalStored(ItemStack cell) {
+        var itemsTag = getItemsTag(cell, false);
+        if (itemsTag == null) {
+            return 0;
+        }
+        int total = 0;
+        for (var key : itemsTag.getAllKeys()) {
+            total += Math.max(0, itemsTag.getInt(key));
+        }
+        return total;
+    }
+
+    public boolean contains(ItemStack cell, Item item) {
+        return getItemCount(cell, item) > 0;
+    }
+
+    public int getItemCount(ItemStack cell, Item item) {
+        var itemsTag = getItemsTag(cell, false);
+        if (itemsTag == null) {
+            return 0;
+        }
+        var id = key(item);
+        return Math.max(0, itemsTag.getInt(id));
+    }
+
+    public int insert(ItemStack cell, Item item, int amount, boolean simulate) {
+        if (amount <= 0) {
+            return 0;
+        }
+        int space = getRemainingCapacity(cell);
+        if (space <= 0) {
+            return 0;
+        }
+        int toInsert = Math.min(space, amount);
+        if (toInsert <= 0) {
+            return 0;
+        }
+        if (!simulate) {
+            var itemsTag = getItemsTag(cell, true);
+            var id = key(item);
+            int current = Math.max(0, itemsTag.getInt(id));
+            itemsTag.putInt(id, current + toInsert);
+        }
+        return toInsert;
+    }
+
+    public int extract(ItemStack cell, Item item, int amount, boolean simulate) {
+        if (amount <= 0) {
+            return 0;
+        }
+        var itemsTag = getItemsTag(cell, false);
+        if (itemsTag == null) {
+            return 0;
+        }
+        var id = key(item);
+        int current = Math.max(0, itemsTag.getInt(id));
+        if (current <= 0) {
+            return 0;
+        }
+        int toExtract = Math.min(current, amount);
+        if (toExtract <= 0) {
+            return 0;
+        }
+        if (!simulate) {
+            if (current == toExtract) {
+                itemsTag.remove(id);
+            } else {
+                itemsTag.putInt(id, current - toExtract);
+            }
+            cleanup(cell, itemsTag);
+        }
+        return toExtract;
+    }
+
+    public List<ItemStackView> getAll(ItemStack cell) {
+        var result = new ArrayList<ItemStackView>();
+        var itemsTag = getItemsTag(cell, false);
+        if (itemsTag == null) {
+            return result;
+        }
+        for (var key : itemsTag.getAllKeys()) {
+            int amount = Math.max(0, itemsTag.getInt(key));
+            if (amount <= 0) {
+                continue;
+            }
+            var item = BuiltInRegistries.ITEM.getOptional(new ResourceLocation(key)).orElse(null);
+            if (item == null || item == Items.AIR) {
+                continue;
+            }
+            result.add(new ItemStackView(item, amount));
+        }
+        return result;
+    }
+
+    private static String key(Item item) {
+        ResourceLocation id = BuiltInRegistries.ITEM.getKey(item);
+        return id.toString();
+    }
+
+    private static void cleanup(ItemStack cell, CompoundTag itemsTag) {
+        if (!itemsTag.getAllKeys().isEmpty()) {
+            return;
+        }
+        var tag = cell.getTag();
+        if (tag == null) {
+            return;
+        }
+        var cellTag = tag.getCompound(CELL_TAG);
+        cellTag.remove(ITEMS_TAG);
+        if (cellTag.isEmpty()) {
+            tag.remove(CELL_TAG);
+        }
+        if (tag.isEmpty()) {
+            cell.setTag(null);
+        }
+    }
+
+    @Nullable
+    private static CompoundTag getItemsTag(ItemStack cell, boolean create) {
+        CompoundTag tag = cell.getTag();
+        if (tag == null) {
+            if (!create) {
+                return null;
+            }
+            tag = new CompoundTag();
+            cell.setTag(tag);
+        }
+
+        CompoundTag cellTag;
+        if (tag.contains(CELL_TAG, Tag.TAG_COMPOUND)) {
+            cellTag = tag.getCompound(CELL_TAG);
+        } else {
+            if (!create) {
+                return null;
+            }
+            cellTag = new CompoundTag();
+            tag.put(CELL_TAG, cellTag);
+        }
+
+        if (cellTag.contains(ITEMS_TAG, Tag.TAG_COMPOUND)) {
+            return cellTag.getCompound(ITEMS_TAG);
+        }
+
+        if (!create) {
+            return null;
+        }
+
+        CompoundTag itemsTag = new CompoundTag();
+        cellTag.put(ITEMS_TAG, itemsTag);
+        return itemsTag;
+    }
+}

--- a/src/main/java/appeng/registry/AE2BlockEntities.java
+++ b/src/main/java/appeng/registry/AE2BlockEntities.java
@@ -6,6 +6,7 @@ import appeng.blockentity.ChargerBlockEntity;
 import appeng.blockentity.ControllerBlockEntity;
 import appeng.blockentity.EnergyAcceptorBlockEntity;
 import appeng.blockentity.InscriberBlockEntity;
+import appeng.blockentity.simple.DriveBlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.neoforged.neoforge.registries.RegistryObject;
 
@@ -19,6 +20,11 @@ public final class AE2BlockEntities {
         AE2Registries.BLOCK_ENTITIES.register("charger",
             () -> BlockEntityType.Builder.of(ChargerBlockEntity::new,
                 AE2Blocks.CHARGER.get()).build(null));
+
+    public static final RegistryObject<BlockEntityType<DriveBlockEntity>> DRIVE_SIMPLE =
+        AE2Registries.BLOCK_ENTITIES.register("drive",
+            () -> BlockEntityType.Builder.of(DriveBlockEntity::new,
+                AE2Blocks.DRIVE.get()).build(null));
 
     public static final RegistryObject<BlockEntityType<ControllerBlockEntity>> CONTROLLER =
         AE2Registries.BLOCK_ENTITIES.register("controller",

--- a/src/main/java/appeng/registry/AE2Blocks.java
+++ b/src/main/java/appeng/registry/AE2Blocks.java
@@ -10,6 +10,8 @@ import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.material.MapColor;
 import net.neoforged.neoforge.registries.RegistryObject;
 
+import appeng.block.simple.DriveBlock;
+
 public final class AE2Blocks {
     public static final RegistryObject<Block> CERTUS_QUARTZ_ORE = AE2Registries.BLOCKS.register(
         "certus_quartz_ore",
@@ -39,6 +41,9 @@ public final class AE2Blocks {
 
     public static final RegistryObject<Block> CABLE =
         AE2Registries.BLOCKS.register("cable", CableBlock::new);
+
+    public static final RegistryObject<Block> DRIVE =
+        AE2Registries.BLOCKS.register("drive", DriveBlock::new);
 
     private AE2Blocks() {}
 }

--- a/src/main/java/appeng/registry/AE2Items.java
+++ b/src/main/java/appeng/registry/AE2Items.java
@@ -6,6 +6,8 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Item.Properties;
 import net.neoforged.neoforge.registries.RegistryObject;
 
+import appeng.items.storage.BasicCell1kItem;
+
 public final class AE2Items {
     public static final RegistryObject<Item> CERTUS_QUARTZ_CRYSTAL = AE2Registries.ITEMS.register(
             "certus_quartz_crystal",
@@ -90,6 +92,14 @@ public final class AE2Items {
     public static final RegistryObject<Item> CABLE = AE2Registries.ITEMS.register(
             "cable",
             () -> new BlockItem(AE2Blocks.CABLE.get(), new Properties()));
+
+    public static final RegistryObject<Item> DRIVE = AE2Registries.ITEMS.register(
+            "drive",
+            () -> new BlockItem(AE2Blocks.DRIVE.get(), new Properties()));
+
+    public static final RegistryObject<Item> BASIC_CELL_1K = AE2Registries.ITEMS.register(
+            "basic_cell_1k",
+            () -> new BasicCell1kItem(new Properties().stacksTo(1)));
 
     private AE2Items() {}
 }

--- a/src/main/java/appeng/storage/impl/ItemStorageChannel.java
+++ b/src/main/java/appeng/storage/impl/ItemStorageChannel.java
@@ -1,19 +1,25 @@
 package appeng.storage.impl;
 
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 import appeng.api.storage.IItemStorageChannel;
+import appeng.api.storage.ItemStackView;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 
 public class ItemStorageChannel implements IItemStorageChannel {
+    private final StorageService service;
     private final List<ItemStack> contents = new ArrayList<>();
+
+    ItemStorageChannel(StorageService service) {
+        this.service = Objects.requireNonNull(service, "service");
+    }
 
     @Override
     public ItemStack insert(ItemStack stack, boolean simulate) {
@@ -21,6 +27,171 @@ public class ItemStorageChannel implements IItemStorageChannel {
             return stack;
         }
 
+        var gridId = service.getGridId();
+        if (gridId != null) {
+            int accepted = StorageService.insertIntoNetwork(gridId, stack.getItem(), stack.getCount(), simulate);
+            stack.shrink(accepted);
+            return stack.isEmpty() ? ItemStack.EMPTY : stack;
+        }
+
+        return insertLocal(stack, simulate);
+    }
+
+    @Override
+    public ItemStack extract(ItemStack filter, int amount, boolean simulate) {
+        if (filter.isEmpty() || amount <= 0) {
+            return ItemStack.EMPTY;
+        }
+
+        var gridId = service.getGridId();
+        if (gridId != null) {
+            int removed = StorageService.extractFromNetwork(gridId, filter.getItem(), amount, simulate);
+            if (removed <= 0) {
+                return ItemStack.EMPTY;
+            }
+            ItemStack result = filter.copy();
+            result.setCount(removed);
+            return result;
+        }
+
+        return extractLocal(filter, amount, simulate);
+    }
+
+    @Override
+    public boolean contains(ItemStack filter) {
+        if (filter.isEmpty()) {
+            return false;
+        }
+
+        var gridId = service.getGridId();
+        if (gridId != null) {
+            return StorageService.networkContains(gridId, filter.getItem());
+        }
+
+        for (var stack : contents) {
+            if (ItemStack.isSameItemSameComponents(stack, filter)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public long insert(ItemStack resource, long amount, boolean simulate) {
+        if (resource.isEmpty() || amount <= 0) {
+            return 0;
+        }
+
+        var gridId = service.getGridId();
+        if (gridId != null) {
+            long inserted = 0;
+            long remaining = amount;
+            while (remaining > 0) {
+                int attempt = (int) Math.min(Integer.MAX_VALUE, remaining);
+                int accepted = StorageService.insertIntoNetwork(gridId, resource.getItem(), attempt, simulate);
+                if (accepted <= 0) {
+                    break;
+                }
+                inserted += accepted;
+                remaining -= accepted;
+                if (accepted < attempt) {
+                    break;
+                }
+            }
+            return inserted;
+        }
+
+        return insertLocal(resource, amount, simulate);
+    }
+
+    @Override
+    public long extract(ItemStack resource, long amount, boolean simulate) {
+        if (resource.isEmpty() || amount <= 0) {
+            return 0;
+        }
+
+        var gridId = service.getGridId();
+        if (gridId != null) {
+            long extracted = 0;
+            long remaining = amount;
+            while (remaining > 0) {
+                int attempt = (int) Math.min(Integer.MAX_VALUE, remaining);
+                int removed = StorageService.extractFromNetwork(gridId, resource.getItem(), attempt, simulate);
+                if (removed <= 0) {
+                    break;
+                }
+                extracted += removed;
+                remaining -= removed;
+                if (removed < attempt) {
+                    break;
+                }
+            }
+            return extracted;
+        }
+
+        return extractLocal(resource, amount, simulate);
+    }
+
+    @Override
+    public long getStoredAmount(ItemStack resource) {
+        if (resource.isEmpty()) {
+            return 0;
+        }
+
+        var gridId = service.getGridId();
+        if (gridId != null) {
+            return StorageService.getNetworkStored(gridId, resource.getItem());
+        }
+
+        long total = 0;
+        for (var stack : contents) {
+            if (ItemStack.isSameItemSameComponents(stack, resource)) {
+                total += stack.getCount();
+            }
+        }
+        return total;
+    }
+
+    @Override
+    public Iterable<ItemStackView> getAll() {
+        var gridId = service.getGridId();
+        if (gridId != null) {
+            return StorageService.getNetworkContents(gridId);
+        }
+
+        List<ItemStackView> result = new ArrayList<>(contents.size());
+        for (var stack : contents) {
+            if (!stack.isEmpty()) {
+                result.add(new ItemStackView(stack.getItem(), stack.getCount()));
+            }
+        }
+        return result;
+    }
+
+    public CompoundTag saveNBT() {
+        CompoundTag tag = new CompoundTag();
+        ListTag list = new ListTag();
+        for (ItemStack stack : contents) {
+            CompoundTag stackTag = new CompoundTag();
+            stack.save(stackTag);
+            list.add(stackTag);
+        }
+        tag.put("Items", list);
+        return tag;
+    }
+
+    public void loadNBT(CompoundTag tag) {
+        contents.clear();
+        if (tag.contains("Items", Tag.TAG_LIST)) {
+            ListTag list = tag.getList("Items", Tag.TAG_COMPOUND);
+            for (int i = 0; i < list.size(); i++) {
+                CompoundTag stackTag = list.getCompound(i);
+                contents.add(ItemStack.of(stackTag));
+            }
+        }
+    }
+
+    private ItemStack insertLocal(ItemStack stack, boolean simulate) {
         for (int i = 0; i < contents.size(); i++) {
             var existing = contents.get(i);
             if (ItemStack.isSameItemSameComponents(existing, stack)) {
@@ -48,12 +219,31 @@ public class ItemStorageChannel implements IItemStorageChannel {
         return stack;
     }
 
-    @Override
-    public ItemStack extract(ItemStack filter, int amount, boolean simulate) {
-        if (filter.isEmpty() || amount <= 0) {
-            return ItemStack.EMPTY;
+    private long insertLocal(ItemStack resource, long amount, boolean simulate) {
+        long inserted = 0;
+        long remaining = amount;
+        while (remaining > 0) {
+            int attemptCount = (int) Math.min(remaining, resource.getMaxStackSize());
+            if (attemptCount <= 0) {
+                break;
+            }
+
+            ItemStack attempt = resource.copy();
+            attempt.setCount(attemptCount);
+            int before = attempt.getCount();
+            ItemStack leftover = insertLocal(attempt, simulate);
+            int after = leftover.isEmpty() ? 0 : leftover.getCount();
+            inserted += before - after;
+            if (after > 0) {
+                break;
+            }
+            remaining -= before;
         }
 
+        return inserted;
+    }
+
+    private ItemStack extractLocal(ItemStack filter, int amount, boolean simulate) {
         Iterator<ItemStack> iterator = contents.iterator();
         while (iterator.hasNext()) {
             var existing = iterator.next();
@@ -80,55 +270,7 @@ public class ItemStorageChannel implements IItemStorageChannel {
         return ItemStack.EMPTY;
     }
 
-    @Override
-    public boolean contains(ItemStack filter) {
-        if (filter.isEmpty()) {
-            return false;
-        }
-
-        for (var stack : contents) {
-            if (ItemStack.isSameItemSameComponents(stack, filter)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    @Override
-    public long insert(ItemStack resource, long amount, boolean simulate) {
-        if (resource.isEmpty() || amount <= 0) {
-            return 0;
-        }
-
-        long inserted = 0;
-        long remaining = amount;
-        while (remaining > 0) {
-            int attemptCount = (int) Math.min(remaining, resource.getMaxStackSize());
-            if (attemptCount <= 0) {
-                break;
-            }
-
-            ItemStack attempt = resource.copy();
-            attempt.setCount(attemptCount);
-            int before = attempt.getCount();
-            ItemStack leftover = insert(attempt, simulate);
-            int after = leftover.isEmpty() ? 0 : leftover.getCount();
-            inserted += before - after;
-            if (after > 0) {
-                break;
-            }
-            remaining -= before;
-        }
-
-        return inserted;
-    }
-
-    @Override
-    public long extract(ItemStack resource, long amount, boolean simulate) {
-        if (resource.isEmpty() || amount <= 0) {
-            return 0;
-        }
-
+    private long extractLocal(ItemStack resource, long amount, boolean simulate) {
         long extracted = 0;
         long remaining = amount;
         while (remaining > 0) {
@@ -137,7 +279,7 @@ public class ItemStorageChannel implements IItemStorageChannel {
                 break;
             }
 
-            ItemStack result = extract(resource, attemptAmount, simulate);
+            ItemStack result = extractLocal(resource, attemptAmount, simulate);
             if (result.isEmpty()) {
                 break;
             }
@@ -150,52 +292,5 @@ public class ItemStorageChannel implements IItemStorageChannel {
         }
 
         return extracted;
-    }
-
-    @Override
-    public long getStoredAmount(ItemStack resource) {
-        if (resource.isEmpty()) {
-            return 0;
-        }
-
-        long total = 0;
-        for (var stack : contents) {
-            if (ItemStack.isSameItemSameComponents(stack, resource)) {
-                total += stack.getCount();
-            }
-        }
-        return total;
-    }
-
-    @Override
-    public Collection<ItemStack> getAll() {
-        List<ItemStack> copy = new ArrayList<>(contents.size());
-        for (var stack : contents) {
-            copy.add(stack.copy());
-        }
-        return Collections.unmodifiableList(copy);
-    }
-
-    public CompoundTag saveNBT() {
-        CompoundTag tag = new CompoundTag();
-        ListTag list = new ListTag();
-        for (ItemStack stack : contents) {
-            CompoundTag stackTag = new CompoundTag();
-            stack.save(stackTag);
-            list.add(stackTag);
-        }
-        tag.put("Items", list);
-        return tag;
-    }
-
-    public void loadNBT(CompoundTag tag) {
-        contents.clear();
-        if (tag.contains("Items", Tag.TAG_LIST)) {
-            ListTag list = tag.getList("Items", Tag.TAG_COMPOUND);
-            for (int i = 0; i < list.size(); i++) {
-                CompoundTag stackTag = list.getCompound(i);
-                contents.add(ItemStack.of(stackTag));
-            }
-        }
     }
 }

--- a/src/main/java/appeng/storage/impl/NetworkItemStorage.java
+++ b/src/main/java/appeng/storage/impl/NetworkItemStorage.java
@@ -1,0 +1,149 @@
+package appeng.storage.impl;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import appeng.blockentity.simple.DriveBlockEntity;
+import appeng.core.AELog;
+import appeng.items.storage.BasicCell1kItem;
+import appeng.api.storage.ItemStackView;
+import appeng.util.GridHelper;
+
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+
+final class NetworkItemStorage {
+    private final UUID gridId;
+    private final Set<DriveBlockEntity> drives = new LinkedHashSet<>();
+    private long totalCapacity;
+    private long totalUsed;
+
+    NetworkItemStorage(UUID gridId) {
+        this.gridId = gridId;
+    }
+
+    synchronized void mountDrive(DriveBlockEntity drive) {
+        drives.add(drive);
+        recalcTotals();
+        AELog.debug("Mounted drive %s on grid %s capacity=%s", drive.getBlockPos(), gridId, totalCapacity);
+    }
+
+    synchronized void unmountDrive(DriveBlockEntity drive) {
+        if (drives.remove(drive)) {
+            recalcTotals();
+            AELog.debug("Unmounted drive %s on grid %s capacity=%s", drive.getBlockPos(), gridId, totalCapacity);
+        }
+    }
+
+    synchronized void refreshDrive(DriveBlockEntity drive) {
+        if (drives.contains(drive)) {
+            recalcTotals();
+            AELog.debug("Refreshed drive %s on grid %s capacity=%s", drive.getBlockPos(), gridId, totalCapacity);
+        }
+    }
+
+    synchronized boolean isEmpty() {
+        return drives.isEmpty();
+    }
+
+    synchronized StorageService.StorageTotals getTotals() {
+        return new StorageService.StorageTotals(totalCapacity, totalUsed);
+    }
+
+    synchronized int insert(Item item, int amount, boolean simulate) {
+        if (amount <= 0) {
+            return 0;
+        }
+        int remaining = amount;
+        for (var cell : cells()) {
+            int inserted = cell.item().insert(cell.stack(), item, remaining, simulate);
+            remaining -= inserted;
+            if (remaining <= 0) {
+                break;
+            }
+        }
+        int accepted = amount - remaining;
+        if (!simulate && accepted > 0) {
+            recalcTotals();
+            GridHelper.updateSetMetadata(gridId);
+        }
+        return accepted;
+    }
+
+    synchronized int extract(Item item, int amount, boolean simulate) {
+        if (amount <= 0) {
+            return 0;
+        }
+        int remaining = amount;
+        for (var cell : cells()) {
+            int extracted = cell.item().extract(cell.stack(), item, remaining, simulate);
+            remaining -= extracted;
+            if (remaining <= 0) {
+                break;
+            }
+        }
+        int removed = amount - remaining;
+        if (!simulate && removed > 0) {
+            recalcTotals();
+            GridHelper.updateSetMetadata(gridId);
+        }
+        return removed;
+    }
+
+    synchronized boolean contains(Item item) {
+        for (var cell : cells()) {
+            if (cell.item().contains(cell.stack(), item)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    synchronized long getStoredAmount(Item item) {
+        long total = 0;
+        for (var cell : cells()) {
+            total += cell.item().getItemCount(cell.stack(), item);
+        }
+        return total;
+    }
+
+    synchronized List<ItemStackView> getAll() {
+        List<ItemStackView> result = new ArrayList<>();
+        for (var cell : cells()) {
+            result.addAll(cell.item().getAll(cell.stack()));
+        }
+        return result;
+    }
+
+    private List<Cell> cells() {
+        List<Cell> result = new ArrayList<>();
+        for (var drive : drives) {
+            int slots = drive.getCellSlotCount();
+            for (int i = 0; i < slots; i++) {
+                ItemStack stack = drive.getCellInSlot(i);
+                if (stack.isEmpty() || !(stack.getItem() instanceof BasicCell1kItem cellItem)) {
+                    continue;
+                }
+                result.add(new Cell(cellItem, stack));
+            }
+        }
+        return result;
+    }
+
+    private void recalcTotals() {
+        long capacity = 0;
+        long used = 0;
+        for (var cell : cells()) {
+            capacity += cell.item().getBytes(cell.stack());
+            used += cell.item().getTotalStored(cell.stack());
+        }
+        this.totalCapacity = capacity;
+        this.totalUsed = used;
+    }
+
+    private record Cell(BasicCell1kItem item, ItemStack stack) {
+    }
+}

--- a/src/main/java/appeng/storage/impl/StorageService.java
+++ b/src/main/java/appeng/storage/impl/StorageService.java
@@ -3,18 +3,30 @@ package appeng.storage.impl;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
 
 import appeng.api.storage.IItemStorageChannel;
 import appeng.api.storage.IStorageChannel;
 import appeng.api.storage.IStorageService;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.world.item.ItemStack;
+import appeng.api.storage.ItemStackView;
+import appeng.blockentity.simple.DriveBlockEntity;
 
 public class StorageService implements IStorageService {
+    private static final Map<UUID, NetworkItemStorage> NETWORKS = new ConcurrentHashMap<>();
+
     private final Map<Class<?>, IStorageChannel<?>> channels = new HashMap<>();
+    private final ItemStorageChannel itemChannel;
+    private UUID gridId;
 
     public StorageService() {
-        channels.put(ItemStack.class, new ItemStorageChannel());
+        this.itemChannel = new ItemStorageChannel(this);
+        channels.put(ItemStack.class, itemChannel);
     }
 
     @SuppressWarnings("unchecked")
@@ -29,7 +41,7 @@ public class StorageService implements IStorageService {
     }
 
     public IItemStorageChannel getItemChannel() {
-        return (IItemStorageChannel) channels.get(ItemStack.class);
+        return itemChannel;
     }
 
     public CompoundTag saveNBT() {
@@ -46,5 +58,117 @@ public class StorageService implements IStorageService {
                 impl.loadNBT(tag.getCompound("ItemChannel"));
             }
         }
+    }
+
+    void attachToGrid(UUID gridId) {
+        if (!Objects.equals(this.gridId, gridId)) {
+            this.gridId = gridId;
+        }
+    }
+
+    void detachFromGrid(UUID gridId) {
+        if (Objects.equals(this.gridId, gridId)) {
+            this.gridId = null;
+        }
+    }
+
+    UUID getGridId() {
+        return gridId;
+    }
+
+    static void mountDrive(UUID gridId, DriveBlockEntity drive) {
+        if (gridId == null) {
+            return;
+        }
+        getOrCreateNetwork(gridId).mountDrive(drive);
+    }
+
+    static void refreshDrive(UUID gridId, DriveBlockEntity drive) {
+        if (gridId == null) {
+            return;
+        }
+        var network = NETWORKS.get(gridId);
+        if (network != null) {
+            network.refreshDrive(drive);
+        }
+    }
+
+    static void unmountDrive(UUID gridId, DriveBlockEntity drive) {
+        if (gridId == null) {
+            return;
+        }
+        var network = NETWORKS.get(gridId);
+        if (network != null) {
+            network.unmountDrive(drive);
+            if (network.isEmpty()) {
+                NETWORKS.remove(gridId);
+            }
+        }
+    }
+
+    static StorageTotals getTotals(UUID gridId) {
+        if (gridId == null) {
+            return new StorageTotals(0, 0);
+        }
+        var network = NETWORKS.get(gridId);
+        if (network == null) {
+            return new StorageTotals(0, 0);
+        }
+        return network.getTotals();
+    }
+
+    static int insertIntoNetwork(UUID gridId, Item item, int amount, boolean simulate) {
+        if (gridId == null || amount <= 0) {
+            return 0;
+        }
+        return getOrCreateNetwork(gridId).insert(item, amount, simulate);
+    }
+
+    static int extractFromNetwork(UUID gridId, Item item, int amount, boolean simulate) {
+        if (gridId == null || amount <= 0) {
+            return 0;
+        }
+        var network = NETWORKS.get(gridId);
+        if (network == null) {
+            return 0;
+        }
+        return network.extract(item, amount, simulate);
+    }
+
+    static boolean networkContains(UUID gridId, Item item) {
+        if (gridId == null) {
+            return false;
+        }
+        var network = NETWORKS.get(gridId);
+        return network != null && network.contains(item);
+    }
+
+    static long getNetworkStored(UUID gridId, Item item) {
+        if (gridId == null) {
+            return 0;
+        }
+        var network = NETWORKS.get(gridId);
+        if (network == null) {
+            return 0;
+        }
+        return network.getStoredAmount(item);
+    }
+
+    static List<ItemStackView> getNetworkContents(UUID gridId) {
+        if (gridId == null) {
+            return List.of();
+        }
+        var network = NETWORKS.get(gridId);
+        if (network == null) {
+            return List.of();
+        }
+        return network.getAll();
+    }
+
+    private static NetworkItemStorage getOrCreateNetwork(UUID gridId) {
+        return NETWORKS.computeIfAbsent(gridId, NetworkItemStorage::new);
+    }
+
+    static record StorageTotals(long totalCapacity, long used) {
     }
 }


### PR DESCRIPTION
## Summary
- add a simple drive bay block and block entity with four cell slots and grid registration
- introduce a basic 1k storage cell item with NBT-backed item counts and expose lightweight ItemStackView records
- extend the storage service and item channel to aggregate cell contents across grids with new network storage tracking and logging

## Testing
- Not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e1c38806748327b56e19b2a5785b91