### PR TITLE
E2 NeoForge Port — Phase 2 PR-5: Meteorite Expansion

### DIFF
--- a/src/generated/resources/data/ae2/forge/biome_modifier/add_meteorites_overworld.json
+++ b/src/generated/resources/data/ae2/forge/biome_modifier/add_meteorites_overworld.json
@@ -1,0 +1,6 @@
+{
+  "type": "neoforge:add_features",
+  "biomes": "#minecraft:is_overworld",
+  "features": "ae2:meteorite",
+  "step": "surface_structures"
+}

--- a/src/generated/resources/data/ae2/loot_tables/chests/meteorite.json
+++ b/src/generated/resources/data/ae2/loot_tables/chests/meteorite.json
@@ -1,0 +1,80 @@
+{
+  "type": "minecraft:chest",
+  "pools": [
+    {
+      "rolls": {
+        "type": "minecraft:uniform",
+        "min": 2.0,
+        "max": 4.0
+      },
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "appliedenergistics2:sky_stone",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "type": "minecraft:uniform",
+                "min": 2.0,
+                "max": 5.0
+              }
+            }
+          ],
+          "weight": 4
+        },
+        {
+          "type": "minecraft:item",
+          "name": "appliedenergistics2:certus_quartz_crystal",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "type": "minecraft:uniform",
+                "min": 1.0,
+                "max": 4.0
+              }
+            }
+          ],
+          "weight": 3
+        },
+        {
+          "type": "minecraft:item",
+          "name": "appliedenergistics2:charged_certus_quartz_crystal",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "type": "minecraft:uniform",
+                "min": 1.0,
+                "max": 2.0
+              }
+            }
+          ],
+          "weight": 1
+        }
+      ]
+    },
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "appliedenergistics2:inscriber_silicon_press"
+        },
+        {
+          "type": "minecraft:item",
+          "name": "appliedenergistics2:inscriber_logic_press"
+        },
+        {
+          "type": "minecraft:item",
+          "name": "appliedenergistics2:inscriber_engineering_press"
+        },
+        {
+          "type": "minecraft:item",
+          "name": "appliedenergistics2:inscriber_calculation_press"
+        }
+      ]
+    }
+  ]
+}

--- a/src/generated/resources/data/ae2/worldgen/configured_feature/meteorite.json
+++ b/src/generated/resources/data/ae2/worldgen/configured_feature/meteorite.json
@@ -1,0 +1,25 @@
+{
+  "type": "appliedenergistics2:meteorite",
+  "config": {
+    "meteorite_block": {
+      "type": "minecraft:simple_state_provider",
+      "state": {
+        "Name": "appliedenergistics2:sky_stone"
+      }
+    },
+    "chest_block": {
+      "type": "minecraft:simple_state_provider",
+      "state": {
+        "Name": "appliedenergistics2:sky_stone_chest"
+      }
+    },
+    "radius": {
+      "type": "minecraft:uniform",
+      "value": {
+        "min_inclusive": 6,
+        "max_inclusive": 14
+      }
+    },
+    "surface_jitter": 2.5
+  }
+}

--- a/src/generated/resources/data/ae2/worldgen/placed_feature/meteorite.json
+++ b/src/generated/resources/data/ae2/worldgen/placed_feature/meteorite.json
@@ -1,0 +1,19 @@
+{
+  "feature": "ae2:meteorite",
+  "placement": [
+    {
+      "type": "minecraft:rarity_filter",
+      "chance": 1200
+    },
+    {
+      "type": "minecraft:in_square"
+    },
+    {
+      "type": "minecraft:heightmap",
+      "heightmap": "motion_blocking_no_leaves"
+    },
+    {
+      "type": "minecraft:biome"
+    }
+  ]
+}

--- a/src/main/java/appeng/AE2Registries.java
+++ b/src/main/java/appeng/AE2Registries.java
@@ -1,6 +1,7 @@
 package appeng;
 
 import net.minecraft.core.registries.Registries;
+import net.minecraft.world.level.levelgen.feature.Feature;
 import net.neoforged.neoforge.registries.DeferredRegister;
 
 public final class AE2Registries {
@@ -22,6 +23,8 @@ public final class AE2Registries {
         DeferredRegister.create(Registries.RECIPE_TYPE, MODID);
     public static final DeferredRegister<net.neoforged.neoforge.loot.GlobalLootModifierSerializer<?>> LOOT_MODIFIERS =
         DeferredRegister.create(Registries.LOOT_MODIFIER_SERIALIZER, MODID);
+    public static final DeferredRegister<Feature<?>> FEATURES =
+        DeferredRegister.create(Registries.FEATURE, MODID);
 
     private AE2Registries() {}
 }

--- a/src/main/java/appeng/core/AppEngBase.java
+++ b/src/main/java/appeng/core/AppEngBase.java
@@ -131,6 +131,7 @@ public abstract class AppEngBase implements AppEng {
         AE2Registries.RECIPE_TYPES.register(modEventBus);
         AE2Registries.SOUNDS.register(modEventBus);
         AE2Registries.LOOT_MODIFIERS.register(modEventBus);
+        AE2Registries.FEATURES.register(modEventBus);
         AE2Registries.CONDITIONS.register(modEventBus);
         AE2LootModifiers.init();
         AE2RecipeSerializers.init();

--- a/src/main/java/appeng/datagen/AE2BiomeModifierProvider.java
+++ b/src/main/java/appeng/datagen/AE2BiomeModifierProvider.java
@@ -12,21 +12,22 @@ import net.minecraft.data.worldgen.BootstrapContext;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.levelgen.GenerationStep;
+import net.minecraft.tags.BiomeTags;
 import net.neoforged.neoforge.common.data.DatapackBuiltinEntriesProvider;
 import net.neoforged.neoforge.common.world.BiomeModifier;
 import net.neoforged.neoforge.common.world.BiomeModifiers;
 
-import appeng.AE2Registries;
+import appeng.core.AppEng;
 import appeng.worldgen.AE2Features;
 
 public class AE2BiomeModifierProvider extends DatapackBuiltinEntriesProvider {
     private static final ResourceKey<BiomeModifier> ADD_CERTUS_QUARTZ = ResourceKey.create(
-        Registries.BIOME_MODIFIER, new ResourceLocation(AE2Registries.MODID, "add_certus_quartz_ore"));
+        Registries.BIOME_MODIFIER, new ResourceLocation(AppEng.MOD_ID, "add_certus_quartz_ore"));
     private static final ResourceKey<BiomeModifier> ADD_METEORITES = ResourceKey.create(
-        Registries.BIOME_MODIFIER, new ResourceLocation(AE2Registries.MODID, "add_meteorites"));
+        Registries.BIOME_MODIFIER, new ResourceLocation(AppEng.MOD_ID, "add_meteorites_overworld"));
 
     public AE2BiomeModifierProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> registries) {
-        super(output, registries, createBuilder(), Set.of(AE2Registries.MODID));
+        super(output, registries, createBuilder(), Set.of(AppEng.MOD_ID));
     }
 
     private static RegistrySetBuilder createBuilder() {
@@ -37,18 +38,17 @@ public class AE2BiomeModifierProvider extends DatapackBuiltinEntriesProvider {
         var biomes = context.lookup(Registries.BIOME);
         var placedFeatures = context.lookup(Registries.PLACED_FEATURE);
 
-        var overworld = biomes.getOrThrow(ResourceKey.create(Registries.BIOME,
-            new ResourceLocation("minecraft", "overworld")));
+        var overworld = biomes.getOrThrow(BiomeTags.IS_OVERWORLD);
         var certusOre = placedFeatures.getOrThrow(AE2Features.CERTUS_QUARTZ_ORE_PLACED);
 
         context.register(ADD_CERTUS_QUARTZ, new BiomeModifiers.AddFeaturesBiomeModifier(
-            HolderSet.direct(overworld),
+            overworld,
             HolderSet.direct(certusOre),
             GenerationStep.Decoration.UNDERGROUND_ORES));
 
         var meteoriteFeature = placedFeatures.getOrThrow(AE2Features.METEORITE_PLACED);
         context.register(ADD_METEORITES, new BiomeModifiers.AddFeaturesBiomeModifier(
-            HolderSet.direct(overworld),
+            overworld,
             HolderSet.direct(meteoriteFeature),
             GenerationStep.Decoration.SURFACE_STRUCTURES));
     }

--- a/src/main/java/appeng/datagen/AE2WorldgenProvider.java
+++ b/src/main/java/appeng/datagen/AE2WorldgenProvider.java
@@ -10,13 +10,17 @@ import net.minecraft.core.registries.Registries;
 import net.minecraft.data.PackOutput;
 import net.minecraft.data.worldgen.BootstrapContext;
 import net.minecraft.tags.BlockTags;
+import net.minecraft.util.valueproviders.UniformInt;
+import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraft.world.level.levelgen.VerticalAnchor;
 import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
 import net.minecraft.world.level.levelgen.feature.Feature;
 import net.minecraft.world.level.levelgen.feature.configurations.OreConfiguration;
+import net.minecraft.world.level.levelgen.feature.stateproviders.SimpleStateProvider;
 import net.minecraft.world.level.levelgen.placement.BiomeFilter;
 import net.minecraft.world.level.levelgen.placement.CountPlacement;
 import net.minecraft.world.level.levelgen.placement.HeightRangePlacement;
+import net.minecraft.world.level.levelgen.placement.HeightmapPlacement;
 import net.minecraft.world.level.levelgen.placement.InSquarePlacement;
 import net.minecraft.world.level.levelgen.placement.PlacedFeature;
 import net.minecraft.world.level.levelgen.placement.PlacementModifier;
@@ -25,14 +29,15 @@ import net.minecraft.world.level.levelgen.structure.templatesystem.RuleTest;
 import net.minecraft.world.level.levelgen.structure.templatesystem.TagMatchTest;
 import net.neoforged.neoforge.common.data.DatapackBuiltinEntriesProvider;
 
-import appeng.AE2Registries;
+import appeng.core.AppEng;
 import appeng.registry.AE2Blocks;
-import appeng.worldgen.config.SphereReplaceConfig;
 import appeng.worldgen.AE2Features;
+import appeng.worldgen.config.MeteoriteConfig;
+import appeng.worldgen.feature.AE2FeatureTypes;
 
 public class AE2WorldgenProvider extends DatapackBuiltinEntriesProvider {
     public AE2WorldgenProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> registries) {
-        super(output, registries, createBuilder(), Set.of(AE2Registries.MODID));
+        super(output, registries, createBuilder(), Set.of(AppEng.MOD_ID));
     }
 
     private static RegistrySetBuilder createBuilder() {
@@ -48,11 +53,12 @@ public class AE2WorldgenProvider extends DatapackBuiltinEntriesProvider {
             AE2Blocks.CERTUS_QUARTZ_ORE.get().defaultBlockState(), 8);
         context.register(AE2Features.CERTUS_QUARTZ_ORE, new ConfiguredFeature<>(Feature.ORE, certusConfig));
 
-        SphereReplaceConfig meteoriteConfig = new SphereReplaceConfig(
-            AE2Blocks.SKY_STONE.get().defaultBlockState(),
-            8,
-            16);
-        context.register(AE2Features.METEORITE, new ConfiguredFeature<>(Feature.DISK, meteoriteConfig));
+        MeteoriteConfig meteoriteConfig = new MeteoriteConfig(
+            SimpleStateProvider.simple(AE2Blocks.SKY_STONE.get().defaultBlockState()),
+            SimpleStateProvider.simple(AE2Blocks.SKY_STONE_CHEST.get().defaultBlockState()),
+            UniformInt.of(6, 14),
+            2.5f);
+        context.register(AE2Features.METEORITE, new ConfiguredFeature<>(AE2FeatureTypes.METEORITE.get(), meteoriteConfig));
     }
 
     private static void bootstrapPlacedFeatures(BootstrapContext<PlacedFeature> context) {
@@ -67,9 +73,9 @@ public class AE2WorldgenProvider extends DatapackBuiltinEntriesProvider {
         context.register(AE2Features.CERTUS_QUARTZ_ORE_PLACED, new PlacedFeature(certus, certusPlacement));
 
         List<PlacementModifier> meteoritePlacement = List.of(
-            RarityFilter.onAverageOnceEvery(200),
+            RarityFilter.onAverageOnceEvery(1200),
             InSquarePlacement.spread(),
-            HeightRangePlacement.uniform(VerticalAnchor.absolute(20), VerticalAnchor.absolute(80)),
+            HeightmapPlacement.onHeightmap(Heightmap.Types.MOTION_BLOCKING_NO_LEAVES),
             BiomeFilter.biome());
         var meteorite = configured.getOrThrow(AE2Features.METEORITE);
         context.register(AE2Features.METEORITE_PLACED, new PlacedFeature(meteorite, meteoritePlacement));

--- a/src/main/java/appeng/datagen/providers/loot/AE2LootTableProvider.java
+++ b/src/main/java/appeng/datagen/providers/loot/AE2LootTableProvider.java
@@ -16,7 +16,8 @@ import net.minecraft.world.level.storage.loot.parameters.LootContextParamSets;
 public class AE2LootTableProvider extends LootTableProvider {
     private static final List<SubProviderEntry> SUB_PROVIDERS = List.of(
             new SubProviderEntry(BlockDropProvider::new, LootContextParamSets.BLOCK),
-            new SubProviderEntry(RaidHeroGiftLootProvider::new, LootContextParamSets.GIFT));
+            new SubProviderEntry(RaidHeroGiftLootProvider::new, LootContextParamSets.GIFT),
+            new SubProviderEntry(MeteoriteChestLootProvider::new, LootContextParamSets.CHEST));
 
     public AE2LootTableProvider(PackOutput packOutput, CompletableFuture<HolderLookup.Provider> provider) {
         super(packOutput, Set.of(), SUB_PROVIDERS, provider);

--- a/src/main/java/appeng/datagen/providers/loot/MeteoriteChestLootProvider.java
+++ b/src/main/java/appeng/datagen/providers/loot/MeteoriteChestLootProvider.java
@@ -1,0 +1,48 @@
+package appeng.datagen.providers.loot;
+
+import java.util.function.BiConsumer;
+
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.storage.loot.LootPool;
+import net.minecraft.world.level.storage.loot.LootTable;
+import net.minecraft.world.level.storage.loot.entries.LootItem;
+import net.minecraft.world.level.storage.loot.functions.SetItemCountFunction;
+import net.minecraft.world.level.storage.loot.providers.number.ConstantValue;
+import net.minecraft.world.level.storage.loot.providers.number.UniformGenerator;
+
+import appeng.core.AppEng;
+import appeng.registry.AE2Items;
+
+public class MeteoriteChestLootProvider implements net.minecraft.data.loot.LootTableSubProvider {
+    private static final ResourceKey<LootTable> METEORITE_CHEST = ResourceKey.create(
+            Registries.LOOT_TABLE, AppEng.makeId("chests/meteorite"));
+
+    public MeteoriteChestLootProvider(HolderLookup.Provider provider) {
+    }
+
+    @Override
+    public void generate(BiConsumer<ResourceKey<LootTable>, LootTable.Builder> consumer) {
+        var lootTable = LootTable.lootTable()
+                .withPool(LootPool.lootPool()
+                        .setRolls(UniformGenerator.between(2.0F, 4.0F))
+                        .add(LootItem.lootTableItem(AE2Items.SKY_STONE.get())
+                                .setWeight(4)
+                                .apply(SetItemCountFunction.setCount(UniformGenerator.between(2.0F, 5.0F))))
+                        .add(LootItem.lootTableItem(AE2Items.CERTUS_QUARTZ_CRYSTAL.get())
+                                .setWeight(3)
+                                .apply(SetItemCountFunction.setCount(UniformGenerator.between(1.0F, 4.0F))))
+                        .add(LootItem.lootTableItem(AE2Items.CHARGED_CERTUS_QUARTZ_CRYSTAL.get())
+                                .setWeight(1)
+                                .apply(SetItemCountFunction.setCount(UniformGenerator.between(1.0F, 2.0F)))))
+                .withPool(LootPool.lootPool()
+                        .setRolls(ConstantValue.exactly(1.0F))
+                        .add(LootItem.lootTableItem(AE2Items.INSCRIBER_SILICON_PRESS.get()))
+                        .add(LootItem.lootTableItem(AE2Items.INSCRIBER_LOGIC_PRESS.get()))
+                        .add(LootItem.lootTableItem(AE2Items.INSCRIBER_ENGINEERING_PRESS.get()))
+                        .add(LootItem.lootTableItem(AE2Items.INSCRIBER_CALCULATION_PRESS.get())));
+
+        consumer.accept(METEORITE_CHEST, lootTable);
+    }
+}

--- a/src/main/java/appeng/registry/AE2Blocks.java
+++ b/src/main/java/appeng/registry/AE2Blocks.java
@@ -6,7 +6,11 @@ import appeng.block.ControllerBlock;
 import appeng.block.EnergyAcceptorBlock;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.ChestBlock;
+import net.minecraft.world.level.block.SoundType;
+import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.properties.BlockSetType;
 import net.minecraft.world.level.material.MapColor;
 import net.neoforged.neoforge.registries.RegistryObject;
 
@@ -33,6 +37,17 @@ public final class AE2Blocks {
         () -> new Block(BlockBehaviour.Properties.of()
             .mapColor(MapColor.COLOR_BLACK)
             .strength(50.0f, 1200.0f)));
+
+    public static final RegistryObject<Block> SKY_STONE_CHEST = AE2Registries.BLOCKS.register(
+        "sky_stone_chest",
+        () -> new ChestBlock(
+            BlockBehaviour.Properties.ofFullCopy(Blocks.CHEST)
+                .mapColor(MapColor.COLOR_BLACK)
+                .sound(SoundType.STONE)
+                .strength(5.0f)
+                .noOcclusion(),
+            () -> BlockEntityType.CHEST,
+            BlockSetType.STONE));
 
     public static final RegistryObject<Block> CONTROLLER =
         AE2Registries.BLOCKS.register("controller", ControllerBlock::new);

--- a/src/main/java/appeng/registry/AE2Items.java
+++ b/src/main/java/appeng/registry/AE2Items.java
@@ -80,6 +80,9 @@ public final class AE2Items {
     public static final RegistryObject<Item> SKY_STONE = AE2Registries.ITEMS.register(
             "sky_stone",
             () -> new BlockItem(AE2Blocks.SKY_STONE.get(), new Properties()));
+    public static final RegistryObject<Item> SKY_STONE_CHEST = AE2Registries.ITEMS.register(
+            "sky_stone_chest",
+            () -> new BlockItem(AE2Blocks.SKY_STONE_CHEST.get(), new Properties()));
 
     public static final RegistryObject<Item> CONTROLLER = AE2Registries.ITEMS.register(
             "controller",

--- a/src/main/java/appeng/worldgen/AE2Features.java
+++ b/src/main/java/appeng/worldgen/AE2Features.java
@@ -6,24 +6,24 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
 import net.minecraft.world.level.levelgen.placement.PlacedFeature;
 
-import appeng.AE2Registries;
+import appeng.core.AppEng;
 
 public final class AE2Features {
     public static final ResourceKey<ConfiguredFeature<?, ?>> CERTUS_QUARTZ_ORE =
         ResourceKey.create(Registries.CONFIGURED_FEATURE,
-            new ResourceLocation(AE2Registries.MODID, "certus_quartz_ore"));
+            new ResourceLocation(AppEng.MOD_ID, "certus_quartz_ore"));
 
     public static final ResourceKey<PlacedFeature> CERTUS_QUARTZ_ORE_PLACED =
         ResourceKey.create(Registries.PLACED_FEATURE,
-            new ResourceLocation(AE2Registries.MODID, "certus_quartz_ore"));
+            new ResourceLocation(AppEng.MOD_ID, "certus_quartz_ore"));
 
     public static final ResourceKey<ConfiguredFeature<?, ?>> METEORITE =
         ResourceKey.create(Registries.CONFIGURED_FEATURE,
-            new ResourceLocation(AE2Registries.MODID, "meteorite"));
+            new ResourceLocation(AppEng.MOD_ID, "meteorite"));
 
     public static final ResourceKey<PlacedFeature> METEORITE_PLACED =
         ResourceKey.create(Registries.PLACED_FEATURE,
-            new ResourceLocation(AE2Registries.MODID, "meteorite"));
+            new ResourceLocation(AppEng.MOD_ID, "meteorite"));
 
     private AE2Features() {}
 }

--- a/src/main/java/appeng/worldgen/config/MeteoriteConfig.java
+++ b/src/main/java/appeng/worldgen/config/MeteoriteConfig.java
@@ -1,0 +1,27 @@
+package appeng.worldgen.config;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+
+import net.minecraft.util.valueproviders.IntProvider;
+import net.minecraft.world.level.levelgen.feature.configurations.FeatureConfiguration;
+import net.minecraft.world.level.levelgen.feature.stateproviders.BlockStateProvider;
+
+/**
+ * Configuration for the {@link appeng.worldgen.feature.MeteoriteFeature}.
+ *
+ * @param meteoriteBlock The block used for the meteorite shell.
+ * @param chestBlock     The block used for the meteorite loot chest.
+ * @param radius         Radius provider for the generated meteorite sphere.
+ * @param surfaceJitter  Amount of random jitter applied to the meteorite surface.
+ */
+public record MeteoriteConfig(BlockStateProvider meteoriteBlock, BlockStateProvider chestBlock,
+        IntProvider radius, float surfaceJitter) implements FeatureConfiguration {
+
+    public static final Codec<MeteoriteConfig> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+            BlockStateProvider.CODEC.fieldOf("meteorite_block").forGetter(MeteoriteConfig::meteoriteBlock),
+            BlockStateProvider.CODEC.fieldOf("chest_block").forGetter(MeteoriteConfig::chestBlock),
+            IntProvider.POSITIVE_CODEC.fieldOf("radius").forGetter(MeteoriteConfig::radius),
+            Codec.FLOAT.optionalFieldOf("surface_jitter", 2.5f).forGetter(MeteoriteConfig::surfaceJitter))
+            .apply(instance, MeteoriteConfig::new));
+}

--- a/src/main/java/appeng/worldgen/feature/AE2FeatureTypes.java
+++ b/src/main/java/appeng/worldgen/feature/AE2FeatureTypes.java
@@ -1,0 +1,14 @@
+package appeng.worldgen.feature;
+
+import net.neoforged.neoforge.registries.RegistryObject;
+
+import appeng.AE2Registries;
+import appeng.worldgen.config.MeteoriteConfig;
+
+public final class AE2FeatureTypes {
+    public static final RegistryObject<MeteoriteFeature> METEORITE =
+            AE2Registries.FEATURES.register("meteorite", () -> new MeteoriteFeature(MeteoriteConfig.CODEC));
+
+    private AE2FeatureTypes() {
+    }
+}

--- a/src/main/java/appeng/worldgen/feature/MeteoriteFeature.java
+++ b/src/main/java/appeng/worldgen/feature/MeteoriteFeature.java
@@ -1,0 +1,239 @@
+package appeng.worldgen.feature;
+
+import java.util.EnumSet;
+
+import com.mojang.serialization.Codec;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.Mth;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.WorldGenLevel;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.ChestBlock;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.RandomizableContainerBlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.core.Direction;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.minecraft.world.level.block.state.properties.ChestType;
+import net.minecraft.world.level.levelgen.Heightmap;
+import net.minecraft.world.level.levelgen.feature.Feature;
+import net.minecraft.world.level.levelgen.feature.FeaturePlaceContext;
+import net.minecraft.world.level.material.FluidState;
+
+import appeng.core.AppEng;
+import appeng.worldgen.config.MeteoriteConfig;
+
+/**
+ * Generates a rough spherical meteorite with a loot chest embedded inside.
+ */
+public class MeteoriteFeature extends Feature<MeteoriteConfig> {
+    private static final EnumSet<Heightmap.Types> SURFACE_HEIGHTMAPS = EnumSet.of(
+            Heightmap.Types.WORLD_SURFACE_WG,
+            Heightmap.Types.MOTION_BLOCKING,
+            Heightmap.Types.MOTION_BLOCKING_NO_LEAVES);
+
+    private static final ResourceLocation LOOT_TABLE = AppEng.makeId("chests/meteorite");
+
+    public MeteoriteFeature(Codec<MeteoriteConfig> codec) {
+        super(codec);
+    }
+
+    @Override
+    public boolean place(FeaturePlaceContext<MeteoriteConfig> context) {
+        var level = context.level();
+        var random = context.random();
+        var origin = context.origin();
+        var config = context.config();
+
+        int surfaceY = sampleSurfaceHeight(level, origin);
+        if (surfaceY <= level.getMinBuildHeight()) {
+            return false;
+        }
+
+        int radius = config.radius().sample(random);
+        if (radius < 1) {
+            return false;
+        }
+
+        int buryDepth = Math.max(2, radius / 2 + random.nextInt(Math.max(1, radius / 3)));
+        int centerY = surfaceY - buryDepth;
+        int minY = level.getMinBuildHeight() + 4;
+        if (centerY < minY) {
+            centerY = minY;
+        }
+
+        BlockPos center = new BlockPos(origin.getX(), centerY, origin.getZ());
+        BlockState meteoriteState = config.meteoriteBlock().getState(random, center);
+
+        var mutablePos = new BlockPos.MutableBlockPos();
+        boolean placedAny = false;
+
+        int radiusSq = radius * radius;
+        int innerRadiusSq = Math.max(1, (radius - 2) * (radius - 2));
+
+        for (int dx = -radius; dx <= radius; dx++) {
+            for (int dy = -radius; dy <= radius; dy++) {
+                for (int dz = -radius; dz <= radius; dz++) {
+                    int distSq = dx * dx + dy * dy + dz * dz;
+                    if (distSq > radiusSq) {
+                        continue;
+                    }
+
+                    mutablePos.setWithOffset(center, dx, dy, dz);
+                    if (!level.getWorldBorder().isWithinBounds(mutablePos) || !withinBuildHeight(level, mutablePos)) {
+                        continue;
+                    }
+
+                    if (!canReplace(level, mutablePos)) {
+                        continue;
+                    }
+
+                    boolean placeBlock = distSq <= innerRadiusSq;
+                    if (!placeBlock) {
+                        double distance = Math.sqrt(distSq);
+                        placeBlock = shouldPlaceWithJitter(mutablePos, distance, radius, config.surfaceJitter());
+                    }
+
+                    if (placeBlock) {
+                        level.setBlock(mutablePos, meteoriteState, Block.UPDATE_ALL);
+                        placedAny = true;
+                    }
+                }
+            }
+        }
+
+        if (!placedAny) {
+            return false;
+        }
+
+        BlockPos chestPos = carveInterior(level, center, radius);
+        placeChest(level, random, chestPos, meteoriteState, config);
+
+        return true;
+    }
+
+    private static int sampleSurfaceHeight(WorldGenLevel level, BlockPos origin) {
+        int highest = level.getMinBuildHeight();
+        for (var type : SURFACE_HEIGHTMAPS) {
+            int height = level.getHeight(type, origin.getX(), origin.getZ());
+            if (height > highest) {
+                highest = height;
+            }
+        }
+        return highest;
+    }
+
+    private static boolean canReplace(LevelAccessor level, BlockPos pos) {
+        var state = level.getBlockState(pos);
+        if (state.isAir()) {
+            return true;
+        }
+
+        FluidState fluid = state.getFluidState();
+        if (!fluid.isEmpty()) {
+            return false;
+        }
+
+        if (state.is(BlockTags.FEATURES_CANNOT_REPLACE)) {
+            return false;
+        }
+
+        return state.canBeReplaced()
+                || state.is(BlockTags.BASE_STONE_OVERWORLD)
+                || state.is(BlockTags.DIRT)
+                || state.is(BlockTags.SAND)
+                || state.is(BlockTags.SNOW);
+    }
+
+    private static boolean shouldPlaceWithJitter(BlockPos pos, double distance, int radius, float jitterAmount) {
+        if (distance <= radius - 1.5) {
+            return true;
+        }
+
+        RandomSource noise = RandomSource.create(Mth.getSeed(pos.getX(), pos.getY(), pos.getZ()));
+        double jitter = (noise.nextDouble() - 0.5) * jitterAmount;
+        return distance <= radius + jitter;
+    }
+
+    private static BlockPos carveInterior(LevelAccessor level, BlockPos center, int radius) {
+        var mutable = new BlockPos.MutableBlockPos();
+        int cavityRadius = Math.max(1, radius / 3);
+        for (int dx = -cavityRadius; dx <= cavityRadius; dx++) {
+            for (int dy = -cavityRadius; dy <= cavityRadius; dy++) {
+                for (int dz = -cavityRadius; dz <= cavityRadius; dz++) {
+                    double distSq = dx * dx + dy * dy + dz * dz;
+                    if (distSq > cavityRadius * cavityRadius) {
+                        continue;
+                    }
+                    mutable.setWithOffset(center, dx, dy, dz);
+                    if (level.getWorldBorder().isWithinBounds(mutable) && withinBuildHeight(level, mutable)) {
+                        level.setBlock(mutable, Blocks.AIR.defaultBlockState(), Block.UPDATE_ALL);
+                    }
+                }
+            }
+        }
+
+        return center;
+    }
+
+    private static void placeChest(LevelAccessor level, RandomSource random, BlockPos center, BlockState meteoriteState,
+            MeteoriteConfig config) {
+        BlockPos chestPos = center.above();
+        if (!level.getWorldBorder().isWithinBounds(chestPos)) {
+            chestPos = center;
+        }
+
+        if (!withinBuildHeight(level, chestPos)) {
+            chestPos = center;
+        }
+
+        if (level.isEmptyBlock(chestPos)) {
+            var below = chestPos.below();
+            if (withinBuildHeight(level, below) && level.isEmptyBlock(below)) {
+                level.setBlock(below, meteoriteState, Block.UPDATE_ALL);
+            }
+        } else {
+            level.setBlock(chestPos, Blocks.AIR.defaultBlockState(), Block.UPDATE_ALL);
+        }
+
+        BlockState chestState = config.chestBlock().getState(random, chestPos);
+        if (chestState.hasProperty(ChestBlock.FACING)) {
+            chestState = chestState.setValue(ChestBlock.FACING,
+                    Direction.Plane.HORIZONTAL.getRandomDirection(random));
+        }
+        if (chestState.hasProperty(ChestBlock.TYPE)) {
+            chestState = chestState.setValue(ChestBlock.TYPE, ChestType.SINGLE);
+        }
+        if (chestState.hasProperty(BlockStateProperties.WATERLOGGED)) {
+            chestState = chestState.setValue(BlockStateProperties.WATERLOGGED, false);
+        }
+
+        level.setBlock(chestPos, chestState, Block.UPDATE_ALL);
+
+        var above = chestPos.above();
+        if (withinBuildHeight(level, above)) {
+            level.setBlock(above, Blocks.AIR.defaultBlockState(), Block.UPDATE_ALL);
+        }
+
+        for (Direction direction : Direction.Plane.HORIZONTAL) {
+            var side = chestPos.relative(direction);
+            if (withinBuildHeight(level, side)) {
+                level.setBlock(side, Blocks.AIR.defaultBlockState(), Block.UPDATE_ALL);
+            }
+        }
+
+        BlockEntity blockEntity = level.getBlockEntity(chestPos);
+        if (blockEntity instanceof RandomizableContainerBlockEntity container) {
+            container.setLootTable(LOOT_TABLE, random.nextLong());
+        }
+    }
+
+    private static boolean withinBuildHeight(LevelAccessor level, BlockPos pos) {
+        return pos.getY() >= level.getMinBuildHeight() && pos.getY() < level.getMaxBuildHeight();
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated MeteoriteFeature with configuration/registration to build irregular sky stone meteorites stocked with loot chests
- wire up worldgen datagen and biome modifiers for the new meteorite feature while introducing the sky stone chest block/item
- supply a meteorite chest loot table provider and generated data for structure, placement, biome modifiers, and loot

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e1d63cc48c8327b0970202011f368d