### PR TITLE
Add crafting terminal block, menu, screen, and assets

### DIFF
--- a/src/generated/resources/assets/ae2/blockstates/crafting_terminal.json
+++ b/src/generated/resources/assets/ae2/blockstates/crafting_terminal.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "ae2:block/crafting_terminal"
+    }
+  }
+}

--- a/src/generated/resources/assets/ae2/lang/en_us.json
+++ b/src/generated/resources/assets/ae2/lang/en_us.json
@@ -115,6 +115,7 @@
   "block.ae2.controller": "ME Controller",
   "block.ae2.crafting_accelerator": "Crafting Co-Processing Unit",
   "block.ae2.crafting_monitor": "Crafting Monitor",
+  "block.ae2.crafting_terminal": "Crafting Terminal",
   "block.ae2.crafting_unit": "Crafting Unit",
   "block.ae2.crank": "Wooden Crank",
   "block.ae2.creative_energy_cell": "Creative Energy Cell",

--- a/src/generated/resources/assets/ae2/models/block/crafting_terminal.json
+++ b/src/generated/resources/assets/ae2/models/block/crafting_terminal.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:block/cube_all",
+  "textures": {
+    "all": "ae2:block/crafting"
+  }
+}

--- a/src/generated/resources/assets/ae2/models/item/crafting_terminal.json
+++ b/src/generated/resources/assets/ae2/models/item/crafting_terminal.json
@@ -1,0 +1,3 @@
+{
+  "parent": "ae2:block/crafting_terminal"
+}

--- a/src/generated/resources/data/ae2/recipe/crafting_terminal.json
+++ b/src/generated/resources/data/ae2/recipe/crafting_terminal.json
@@ -1,0 +1,14 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "ae2:terminal"
+    },
+    {
+      "item": "minecraft:crafting_table"
+    }
+  ],
+  "result": {
+    "item": "ae2:crafting_terminal"
+  }
+}

--- a/src/main/java/appeng/block/terminal/CraftingTerminalBlock.java
+++ b/src/main/java/appeng/block/terminal/CraftingTerminalBlock.java
@@ -1,0 +1,37 @@
+package appeng.block.terminal;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.BlockHitResult;
+
+import org.jetbrains.annotations.Nullable;
+
+import appeng.blockentity.terminal.CraftingTerminalBlockEntity;
+import appeng.menu.MenuOpener;
+import appeng.menu.locator.MenuLocators;
+import appeng.menu.terminal.CraftingTerminalMenu;
+
+public class CraftingTerminalBlock extends TerminalBlock {
+    @Nullable
+    @Override
+    public BlockEntity newBlockEntity(BlockPos pos, BlockState state) {
+        return new CraftingTerminalBlockEntity(pos, state);
+    }
+
+    @Override
+    protected InteractionResult useWithoutItem(BlockState state, Level level, BlockPos pos, Player player,
+            BlockHitResult hitResult) {
+        if (level.getBlockEntity(pos) instanceof CraftingTerminalBlockEntity terminal) {
+            if (!level.isClientSide()) {
+                MenuOpener.open(CraftingTerminalMenu.TYPE, player, MenuLocators.forBlockEntity(terminal));
+            }
+            return InteractionResult.sidedSuccess(level.isClientSide());
+        }
+
+        return super.useWithoutItem(state, level, pos, player, hitResult);
+    }
+}

--- a/src/main/java/appeng/blockentity/terminal/CraftingTerminalBlockEntity.java
+++ b/src/main/java/appeng/blockentity/terminal/CraftingTerminalBlockEntity.java
@@ -1,0 +1,226 @@
+package appeng.blockentity.terminal;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.NonNullList;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.Container;
+import net.minecraft.world.ContainerHelper;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.state.BlockState;
+
+import appeng.registry.AE2BlockEntities;
+
+public class CraftingTerminalBlockEntity extends TerminalBlockEntity {
+    private static final int MATRIX_SIZE = 9;
+    private static final int RESULT_SLOT = 9;
+
+    private final NonNullList<ItemStack> items = NonNullList.withSize(MATRIX_SIZE + 1, ItemStack.EMPTY);
+
+    private final Container craftingMatrix = new Container() {
+        @Override
+        public int getContainerSize() {
+            return MATRIX_SIZE;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            for (int i = 0; i < MATRIX_SIZE; i++) {
+                if (!items.get(i).isEmpty()) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public ItemStack getItem(int index) {
+            return items.get(index);
+        }
+
+        @Override
+        public ItemStack removeItem(int index, int count) {
+            ItemStack removed = ContainerHelper.removeItem(items, index, count);
+            if (!removed.isEmpty()) {
+                setChanged();
+            }
+            return removed;
+        }
+
+        @Override
+        public ItemStack removeItemNoUpdate(int index) {
+            ItemStack stack = items.get(index);
+            if (stack.isEmpty()) {
+                return ItemStack.EMPTY;
+            }
+            items.set(index, ItemStack.EMPTY);
+            setChanged();
+            return stack;
+        }
+
+        @Override
+        public void setItem(int index, ItemStack stack) {
+            items.set(index, stack);
+            if (!stack.isEmpty() && stack.getCount() > getMaxStackSize()) {
+                stack.setCount(getMaxStackSize());
+            }
+            setChanged();
+        }
+
+        @Override
+        public int getMaxStackSize() {
+            return 64;
+        }
+
+        @Override
+        public void setChanged() {
+            CraftingTerminalBlockEntity.this.setChanged();
+        }
+
+        @Override
+        public boolean stillValid(Player player) {
+            return true;
+        }
+
+        @Override
+        public void clearContent() {
+            for (int i = 0; i < MATRIX_SIZE; i++) {
+                items.set(i, ItemStack.EMPTY);
+            }
+            setChanged();
+        }
+
+        @Override
+        public void startOpen(Player player) {
+        }
+
+        @Override
+        public void stopOpen(Player player) {
+        }
+
+        @Override
+        public boolean canPlaceItem(int index, ItemStack stack) {
+            return true;
+        }
+    };
+
+    private final Container resultInventory = new Container() {
+        @Override
+        public int getContainerSize() {
+            return 1;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return items.get(RESULT_SLOT).isEmpty();
+        }
+
+        @Override
+        public ItemStack getItem(int index) {
+            return items.get(RESULT_SLOT);
+        }
+
+        @Override
+        public ItemStack removeItem(int index, int count) {
+            ItemStack removed = ContainerHelper.removeItem(items, RESULT_SLOT, count);
+            if (!removed.isEmpty()) {
+                setChanged();
+            }
+            return removed;
+        }
+
+        @Override
+        public ItemStack removeItemNoUpdate(int index) {
+            ItemStack stack = items.get(RESULT_SLOT);
+            items.set(RESULT_SLOT, ItemStack.EMPTY);
+            if (!stack.isEmpty()) {
+                setChanged();
+            }
+            return stack;
+        }
+
+        @Override
+        public void setItem(int index, ItemStack stack) {
+            items.set(RESULT_SLOT, stack);
+            if (!stack.isEmpty() && stack.getCount() > getMaxStackSize()) {
+                stack.setCount(getMaxStackSize());
+            }
+            setChanged();
+        }
+
+        @Override
+        public int getMaxStackSize() {
+            return 64;
+        }
+
+        @Override
+        public void setChanged() {
+            CraftingTerminalBlockEntity.this.setChanged();
+        }
+
+        @Override
+        public boolean stillValid(Player player) {
+            return true;
+        }
+
+        @Override
+        public void clearContent() {
+            items.set(RESULT_SLOT, ItemStack.EMPTY);
+            setChanged();
+        }
+
+        @Override
+        public void startOpen(Player player) {
+        }
+
+        @Override
+        public void stopOpen(Player player) {
+        }
+
+        @Override
+        public boolean canPlaceItem(int index, ItemStack stack) {
+            return false;
+        }
+    };
+
+    public CraftingTerminalBlockEntity(BlockPos pos, BlockState state) {
+        super(AE2BlockEntities.CRAFTING_TERMINAL.get(), pos, state);
+    }
+
+    public Container getCraftingMatrix() {
+        return craftingMatrix;
+    }
+
+    public Container getResultInventory() {
+        return resultInventory;
+    }
+
+    public NonNullList<ItemStack> getMatrixItems() {
+        NonNullList<ItemStack> list = NonNullList.withSize(MATRIX_SIZE, ItemStack.EMPTY);
+        for (int i = 0; i < MATRIX_SIZE; i++) {
+            list.set(i, items.get(i));
+        }
+        return list;
+    }
+
+    public ItemStack getResultItem() {
+        return items.get(RESULT_SLOT);
+    }
+
+    public void setResultItem(ItemStack stack) {
+        items.set(RESULT_SLOT, stack);
+        setChanged();
+    }
+
+    @Override
+    public void load(CompoundTag tag) {
+        super.load(tag);
+        ContainerHelper.loadAllItems(tag, items);
+    }
+
+    @Override
+    protected void saveAdditional(CompoundTag tag) {
+        super.saveAdditional(tag);
+        ContainerHelper.saveAllItems(tag, items);
+    }
+}

--- a/src/main/java/appeng/client/AE2ClientSetup.java
+++ b/src/main/java/appeng/client/AE2ClientSetup.java
@@ -8,6 +8,7 @@ import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
 
 import appeng.AE2Registries;
 import appeng.client.screen.ChargerScreen;
+import appeng.client.screen.CraftingTerminalScreen;
 import appeng.client.screen.InscriberScreen;
 import appeng.client.screen.TerminalScreen;
 import appeng.registry.AE2Menus;
@@ -22,6 +23,7 @@ public final class AE2ClientSetup {
         event.enqueueWork(() -> {
             MenuScreens.register(AE2Menus.INSCRIBER_MENU.get(), InscriberScreen::new);
             MenuScreens.register(AE2Menus.CHARGER_MENU.get(), ChargerScreen::new);
+            MenuScreens.register(AE2Menus.CRAFTING_TERMINAL_MENU.get(), CraftingTerminalScreen::new);
             MenuScreens.register(TerminalMenu.TYPE, TerminalScreen::new);
         });
     }

--- a/src/main/java/appeng/client/screen/CraftingTerminalScreen.java
+++ b/src/main/java/appeng/client/screen/CraftingTerminalScreen.java
@@ -1,0 +1,66 @@
+package appeng.client.screen;
+
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Inventory;
+
+import appeng.menu.terminal.CraftingTerminalMenu;
+
+public class CraftingTerminalScreen extends TerminalScreen {
+    private static final int GRID_SIZE = 3;
+    private static final int SLOT_SIZE = 18;
+    private static final int GRID_LEFT_OFFSET = 8;
+    private static final int GRID_TOP_OFFSET = 28;
+    private static final int RESULT_LEFT_OFFSET = GRID_LEFT_OFFSET + GRID_SIZE * SLOT_SIZE + 12;
+    private static final int RESULT_TOP_OFFSET = GRID_TOP_OFFSET + SLOT_SIZE;
+    private static final int GRID_BOTTOM_MARGIN = 12;
+
+    public CraftingTerminalScreen(CraftingTerminalMenu menu, Inventory inv, Component title) {
+        super(menu, inv, title);
+        this.imageHeight = 190 + GRID_SIZE * SLOT_SIZE + GRID_BOTTOM_MARGIN;
+    }
+
+    @Override
+    protected int getListTopOffset() {
+        return GRID_TOP_OFFSET + GRID_SIZE * SLOT_SIZE + GRID_BOTTOM_MARGIN;
+    }
+
+    @Override
+    public void render(GuiGraphics graphics, int mouseX, int mouseY, float partialTick) {
+        super.render(graphics, mouseX, mouseY, partialTick);
+        if (!this.menu.isGridOnline()) {
+            renderGridOfflineOverlay(graphics);
+        }
+    }
+
+    @Override
+    protected void renderBg(GuiGraphics graphics, float partialTicks, int mouseX, int mouseY) {
+        super.renderBg(graphics, partialTicks, mouseX, mouseY);
+
+        int left = this.leftPos + GRID_LEFT_OFFSET;
+        int top = this.topPos + GRID_TOP_OFFSET;
+        for (int row = 0; row < GRID_SIZE; row++) {
+            for (int col = 0; col < GRID_SIZE; col++) {
+                int slotX = left + col * SLOT_SIZE;
+                int slotY = top + row * SLOT_SIZE;
+                graphics.fill(slotX, slotY, slotX + 16, slotY + 16, 0xFF3F3F3F);
+            }
+        }
+
+        int resultX = this.leftPos + RESULT_LEFT_OFFSET;
+        int resultY = this.topPos + RESULT_TOP_OFFSET;
+        graphics.fill(resultX, resultY, resultX + 16, resultY + 16, 0xFF3F3F3F);
+    }
+
+    private void renderGridOfflineOverlay(GuiGraphics graphics) {
+        int left = this.leftPos + GRID_LEFT_OFFSET;
+        int top = this.topPos + GRID_TOP_OFFSET;
+        int width = GRID_SIZE * SLOT_SIZE;
+        int height = GRID_SIZE * SLOT_SIZE;
+        graphics.fill(left, top, left + width, top + height, 0xAA000000);
+
+        int resultX = this.leftPos + RESULT_LEFT_OFFSET;
+        int resultY = this.topPos + RESULT_TOP_OFFSET;
+        graphics.fill(resultX, resultY, resultX + 16, resultY + 16, 0xAA000000);
+    }
+}

--- a/src/main/java/appeng/client/screen/TerminalScreen.java
+++ b/src/main/java/appeng/client/screen/TerminalScreen.java
@@ -23,7 +23,6 @@ public class TerminalScreen extends AbstractContainerScreen<TerminalMenu> {
     private static final int SLOT_SIZE = 18;
     private static final int ITEMS_PER_ROW = 4;
     private static final int VISIBLE_ROWS = 3;
-    private static final int ITEMS_PER_PAGE = ITEMS_PER_ROW * VISIBLE_ROWS;
     private static final int LIST_LEFT_OFFSET = 7;
     private static final int LIST_TOP_OFFSET = 24;
 
@@ -31,6 +30,38 @@ public class TerminalScreen extends AbstractContainerScreen<TerminalMenu> {
     private int scrollIndex;
     private boolean scrolling;
     private List<ItemStackView> currentItems = List.of();
+
+    protected int getSlotSize() {
+        return SLOT_SIZE;
+    }
+
+    protected int getItemsPerRow() {
+        return ITEMS_PER_ROW;
+    }
+
+    protected int getVisibleRows() {
+        return VISIBLE_ROWS;
+    }
+
+    protected int getListLeftOffset() {
+        return LIST_LEFT_OFFSET;
+    }
+
+    protected int getListTopOffset() {
+        return LIST_TOP_OFFSET;
+    }
+
+    protected int getItemsPerPage() {
+        return getItemsPerRow() * getVisibleRows();
+    }
+
+    protected int getListLeft() {
+        return this.leftPos + getListLeftOffset();
+    }
+
+    protected int getListTop() {
+        return this.topPos + getListTopOffset();
+    }
 
     public TerminalScreen(TerminalMenu menu, Inventory inv, Component title) {
         super(menu, inv, title);
@@ -84,10 +115,10 @@ public class TerminalScreen extends AbstractContainerScreen<TerminalMenu> {
     @Override
     public boolean mouseClicked(double mouseX, double mouseY, int button) {
         boolean handled = super.mouseClicked(mouseX, mouseY, button);
-        int scrollbarX = this.leftPos + LIST_LEFT_OFFSET + ITEMS_PER_ROW * SLOT_SIZE + 4;
-        int scrollbarY = this.topPos + LIST_TOP_OFFSET;
+        int scrollbarX = getListLeft() + getItemsPerRow() * getSlotSize() + 4;
+        int scrollbarY = getListTop();
         int scrollbarWidth = 6;
-        int scrollbarHeight = VISIBLE_ROWS * SLOT_SIZE;
+        int scrollbarHeight = getVisibleRows() * getSlotSize();
         if (mouseX >= scrollbarX && mouseX <= scrollbarX + scrollbarWidth && mouseY >= scrollbarY
                 && mouseY <= scrollbarY + scrollbarHeight) {
             this.scrolling = true;
@@ -118,10 +149,10 @@ public class TerminalScreen extends AbstractContainerScreen<TerminalMenu> {
 
     @Override
     public boolean mouseScrolled(double mouseX, double mouseY, double delta) {
-        int listX = this.leftPos + LIST_LEFT_OFFSET;
-        int listY = this.topPos + LIST_TOP_OFFSET;
-        int listWidth = ITEMS_PER_ROW * SLOT_SIZE;
-        int listHeight = VISIBLE_ROWS * SLOT_SIZE;
+        int listX = getListLeft();
+        int listY = getListTop();
+        int listWidth = getItemsPerRow() * getSlotSize();
+        int listHeight = getVisibleRows() * getSlotSize();
         if (mouseX >= listX && mouseX <= listX + listWidth && mouseY >= listY && mouseY <= listY + listHeight) {
             int maxScroll = getMaxScroll();
             if (maxScroll > 0) {
@@ -155,15 +186,15 @@ public class TerminalScreen extends AbstractContainerScreen<TerminalMenu> {
         int y = this.topPos;
         graphics.fill(x, y, x + this.imageWidth, y + this.imageHeight, 0xFF2F2F2F);
 
-        int listX = x + LIST_LEFT_OFFSET;
-        int listY = y + LIST_TOP_OFFSET;
+        int listX = getListLeft();
+        int listY = getListTop();
         int startIndex = this.scrollIndex;
 
-        for (int row = 0; row < VISIBLE_ROWS; row++) {
-            for (int col = 0; col < ITEMS_PER_ROW; col++) {
-                int index = startIndex + row * ITEMS_PER_ROW + col;
-                int slotX = listX + col * SLOT_SIZE;
-                int slotY = listY + row * SLOT_SIZE;
+        for (int row = 0; row < getVisibleRows(); row++) {
+            for (int col = 0; col < getItemsPerRow(); col++) {
+                int index = startIndex + row * getItemsPerRow() + col;
+                int slotX = listX + col * getSlotSize();
+                int slotY = listY + row * getSlotSize();
                 graphics.fill(slotX, slotY, slotX + 16, slotY + 16, 0xFF3F3F3F);
                 if (index < this.currentItems.size()) {
                     ItemStackView view = this.currentItems.get(index);
@@ -205,10 +236,10 @@ public class TerminalScreen extends AbstractContainerScreen<TerminalMenu> {
     }
 
     private void drawScrollbar(GuiGraphics graphics, int listX, int listY) {
-        int barX = listX + ITEMS_PER_ROW * SLOT_SIZE + 4;
+        int barX = listX + getItemsPerRow() * getSlotSize() + 4;
         int barY = listY;
         int barWidth = 6;
-        int barHeight = VISIBLE_ROWS * SLOT_SIZE;
+        int barHeight = getVisibleRows() * getSlotSize();
         graphics.fill(barX, barY, barX + barWidth, barY + barHeight, 0xFF1B1B1B);
 
         int handleHeight = getScrollHandleHeight(barHeight);
@@ -220,22 +251,22 @@ public class TerminalScreen extends AbstractContainerScreen<TerminalMenu> {
     }
 
     private int getScrollHandleHeight(int barHeight) {
-        if (this.currentItems.size() <= ITEMS_PER_PAGE) {
+        if (this.currentItems.size() <= getItemsPerPage()) {
             return barHeight;
         }
         int handle = (int) Math.max(8,
-                Math.floor((double) barHeight * ITEMS_PER_PAGE / (double) this.currentItems.size()));
+                Math.floor((double) barHeight * getItemsPerPage() / (double) this.currentItems.size()));
         return Math.min(barHeight, handle);
     }
 
     private int getMaxScroll() {
-        int max = this.currentItems.size() - ITEMS_PER_PAGE;
+        int max = this.currentItems.size() - getItemsPerPage();
         return Math.max(0, max);
     }
 
     private void updateScrollFromY(double mouseY) {
-        int barTop = this.topPos + LIST_TOP_OFFSET;
-        int barHeight = VISIBLE_ROWS * SLOT_SIZE;
+        int barTop = getListTop();
+        int barHeight = getVisibleRows() * getSlotSize();
         int handleHeight = getScrollHandleHeight(barHeight);
         double relative = (mouseY - barTop - handleHeight / 2.0) / (barHeight - handleHeight);
         relative = Mth.clamp(relative, 0.0, 1.0);
@@ -244,10 +275,10 @@ public class TerminalScreen extends AbstractContainerScreen<TerminalMenu> {
     }
 
     private void renderOfflineOverlay(GuiGraphics graphics) {
-        int x = this.leftPos + LIST_LEFT_OFFSET;
-        int y = this.topPos + LIST_TOP_OFFSET;
-        int width = ITEMS_PER_ROW * SLOT_SIZE;
-        int height = VISIBLE_ROWS * SLOT_SIZE;
+        int x = getListLeft();
+        int y = getListTop();
+        int width = getItemsPerRow() * getSlotSize();
+        int height = getVisibleRows() * getSlotSize();
         graphics.fill(x, y, x + width, y + height, 0xAA000000);
         Component offline = Component.literal("OFFLINE");
         int textWidth = this.font.width(offline);
@@ -265,10 +296,10 @@ public class TerminalScreen extends AbstractContainerScreen<TerminalMenu> {
     }
 
     private boolean isWithinItemArea(double mouseX, double mouseY) {
-        int listX = this.leftPos + LIST_LEFT_OFFSET;
-        int listY = this.topPos + LIST_TOP_OFFSET;
-        int listWidth = ITEMS_PER_ROW * SLOT_SIZE;
-        int listHeight = VISIBLE_ROWS * SLOT_SIZE;
+        int listX = getListLeft();
+        int listY = getListTop();
+        int listWidth = getItemsPerRow() * getSlotSize();
+        int listHeight = getVisibleRows() * getSlotSize();
         return mouseX >= listX && mouseX < listX + listWidth && mouseY >= listY && mouseY < listY + listHeight;
     }
 
@@ -277,15 +308,15 @@ public class TerminalScreen extends AbstractContainerScreen<TerminalMenu> {
             return;
         }
 
-        int listX = this.leftPos + LIST_LEFT_OFFSET;
-        int listY = this.topPos + LIST_TOP_OFFSET;
-        int col = (int) ((mouseX - listX) / SLOT_SIZE);
-        int row = (int) ((mouseY - listY) / SLOT_SIZE);
-        if (col < 0 || col >= ITEMS_PER_ROW || row < 0 || row >= VISIBLE_ROWS) {
+        int listX = getListLeft();
+        int listY = getListTop();
+        int col = (int) ((mouseX - listX) / getSlotSize());
+        int row = (int) ((mouseY - listY) / getSlotSize());
+        if (col < 0 || col >= getItemsPerRow() || row < 0 || row >= getVisibleRows()) {
             return;
         }
 
-        int index = this.scrollIndex + row * ITEMS_PER_ROW + col;
+        int index = this.scrollIndex + row * getItemsPerRow() + col;
         if (index < 0 || index >= this.currentItems.size()) {
             return;
         }

--- a/src/main/java/appeng/menu/terminal/CraftingTerminalMenu.java
+++ b/src/main/java/appeng/menu/terminal/CraftingTerminalMenu.java
@@ -1,0 +1,189 @@
+package appeng.menu.terminal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.core.NonNullList;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.Container;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.MenuType;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.CraftingInput;
+import net.minecraft.world.item.crafting.CraftingRecipe;
+import net.minecraft.world.item.crafting.RecipeHolder;
+import net.minecraft.world.item.crafting.RecipeType;
+import net.minecraft.world.level.Level;
+
+import appeng.blockentity.terminal.CraftingTerminalBlockEntity;
+import appeng.core.AppEng;
+import appeng.menu.SlotSemantics;
+import appeng.menu.implementations.MenuTypeBuilder;
+import appeng.storage.impl.StorageService;
+
+public class CraftingTerminalMenu extends TerminalMenu {
+    public static final MenuType<CraftingTerminalMenu> TYPE = MenuTypeBuilder
+            .create(CraftingTerminalMenu::new, CraftingTerminalBlockEntity.class)
+            .buildUnregistered(AppEng.makeId("crafting_terminal"));
+
+    private static final int GRID_COLUMNS = 3;
+    private static final int GRID_ROWS = 3;
+    private static final int SLOT_SIZE = 18;
+    private static final int GRID_LEFT = 8;
+    private static final int GRID_TOP = 28;
+    private static final int RESULT_OFFSET_X = GRID_LEFT + GRID_COLUMNS * SLOT_SIZE + 12;
+    private static final int RESULT_OFFSET_Y = GRID_TOP + SLOT_SIZE;
+
+    private final CraftingTerminalBlockEntity craftingTerminal;
+    private final Container craftingMatrix;
+    private final Container resultInventory;
+    @Nullable
+    private RecipeHolder<CraftingRecipe> currentRecipe;
+
+    public CraftingTerminalMenu(int id, Inventory inv, CraftingTerminalBlockEntity terminal) {
+        super(TYPE, id, inv, terminal);
+        this.craftingTerminal = terminal;
+        this.craftingMatrix = terminal.getCraftingMatrix();
+        this.resultInventory = terminal.getResultInventory();
+
+        for (int row = 0; row < GRID_ROWS; row++) {
+            for (int col = 0; col < GRID_COLUMNS; col++) {
+                int slotIndex = row * GRID_COLUMNS + col;
+                int x = GRID_LEFT + col * SLOT_SIZE;
+                int y = GRID_TOP + row * SLOT_SIZE;
+                Slot slot = new Slot(craftingMatrix, slotIndex, x, y);
+                addSlot(slot, SlotSemantics.MACHINE_CRAFTING_GRID);
+            }
+        }
+
+        Slot resultSlot = new Slot(resultInventory, 0, RESULT_OFFSET_X, RESULT_OFFSET_Y) {
+            @Override
+            public boolean mayPlace(ItemStack stack) {
+                return false;
+            }
+
+            @Override
+            public void onTake(Player player, ItemStack stack) {
+                craftResult(player, stack);
+                super.onTake(player, stack);
+            }
+        };
+        addSlot(resultSlot, SlotSemantics.CRAFTING_RESULT);
+
+        if (!inv.player.level().isClientSide()) {
+            updateCraftingResult();
+        }
+    }
+
+    @Override
+    public void slotsChanged(Container container) {
+        super.slotsChanged(container);
+        if (container == craftingMatrix && !getPlayer().level().isClientSide()) {
+            updateCraftingResult();
+        }
+    }
+
+    @Override
+    protected int transferStackToMenu(ItemStack input) {
+        if (isGridOnline()) {
+            var node = craftingTerminal.getGridNode();
+            var gridId = node != null ? node.getGridId() : null;
+            int inserted = StorageService.insertIntoNetwork(gridId, input.getItem(), input.getCount(), false);
+            if (inserted > 0) {
+                return inserted;
+            }
+        }
+        return super.transferStackToMenu(input);
+    }
+
+    private void updateCraftingResult() {
+        Level level = getPlayer().level();
+        if (level == null) {
+            return;
+        }
+
+        currentRecipe = null;
+        ItemStack result = ItemStack.EMPTY;
+
+        List<ItemStack> contents = new ArrayList<>(GRID_ROWS * GRID_COLUMNS);
+        for (int i = 0; i < GRID_ROWS * GRID_COLUMNS; i++) {
+            contents.add(craftingMatrix.getItem(i).copy());
+        }
+
+        CraftingInput input = CraftingInput.of(GRID_COLUMNS, GRID_ROWS, contents);
+        var recipe = level.getRecipeManager().getRecipeFor(RecipeType.CRAFTING, input, level);
+        if (recipe.isPresent()) {
+            RecipeHolder<CraftingRecipe> holder = recipe.get();
+            ItemStack assembled = holder.value().assemble(input, level.registryAccess());
+            if (!assembled.isEmpty()) {
+                result = assembled;
+                currentRecipe = holder;
+            }
+        }
+
+        resultInventory.setItem(0, result);
+        broadcastChanges();
+    }
+
+    private void craftResult(Player player, ItemStack stack) {
+        Level level = player.level();
+        if (level.isClientSide()) {
+            return;
+        }
+        if (currentRecipe == null) {
+            updateCraftingResult();
+            return;
+        }
+
+        CraftingInput input = CraftingInput.of(GRID_COLUMNS, GRID_ROWS, getMatrixSnapshot());
+        RecipeHolder<CraftingRecipe> holder = currentRecipe;
+        if (!holder.value().matches(input, level)) {
+            updateCraftingResult();
+            return;
+        }
+
+        RegistryAccess registries = level.registryAccess();
+        ItemStack output = holder.value().assemble(input, registries);
+        if (output.isEmpty()) {
+            updateCraftingResult();
+            return;
+        }
+
+        NonNullList<ItemStack> remaining = holder.value().getRemainingItems(input);
+        for (int i = 0; i < remaining.size(); i++) {
+            ItemStack slotStack = craftingMatrix.getItem(i);
+            if (!slotStack.isEmpty()) {
+                craftingMatrix.removeItem(i, 1);
+                slotStack = craftingMatrix.getItem(i);
+            }
+
+            ItemStack remainder = remaining.get(i);
+            if (!remainder.isEmpty()) {
+                if (slotStack.isEmpty()) {
+                    craftingMatrix.setItem(i, remainder);
+                } else if (getPlayer() instanceof ServerPlayer serverPlayer) {
+                    if (!serverPlayer.getInventory().add(remainder)) {
+                        serverPlayer.drop(remainder, false);
+                    }
+                }
+            }
+        }
+
+        stack.onCraftedBy(level, player, stack.getCount());
+        resultInventory.setItem(0, ItemStack.EMPTY);
+        updateCraftingResult();
+    }
+
+    private List<ItemStack> getMatrixSnapshot() {
+        List<ItemStack> contents = new ArrayList<>(GRID_ROWS * GRID_COLUMNS);
+        for (int i = 0; i < GRID_ROWS * GRID_COLUMNS; i++) {
+            contents.add(craftingMatrix.getItem(i).copy());
+        }
+        return contents;
+    }
+}

--- a/src/main/java/appeng/menu/terminal/TerminalMenu.java
+++ b/src/main/java/appeng/menu/terminal/TerminalMenu.java
@@ -32,11 +32,16 @@ public class TerminalMenu extends AEBaseMenu {
     private List<ItemStackView> clientItems = new ArrayList<>();
     private boolean clientOnline;
 
-    public TerminalMenu(int id, Inventory inv, TerminalBlockEntity terminal) {
-        super(TYPE, id, inv, terminal);
+    protected TerminalMenu(MenuType<? extends TerminalMenu> type, int id, Inventory inv,
+            TerminalBlockEntity terminal) {
+        super(type, id, inv, terminal);
         this.terminal = terminal;
         this.player = inv.player;
         this.createPlayerInventorySlots(inv);
+    }
+
+    public TerminalMenu(int id, Inventory inv, TerminalBlockEntity terminal) {
+        this(TYPE, id, inv, terminal);
     }
 
     @Override

--- a/src/main/java/appeng/registry/AE2BlockEntities.java
+++ b/src/main/java/appeng/registry/AE2BlockEntities.java
@@ -7,6 +7,7 @@ import appeng.blockentity.ControllerBlockEntity;
 import appeng.blockentity.EnergyAcceptorBlockEntity;
 import appeng.blockentity.InscriberBlockEntity;
 import appeng.blockentity.simple.DriveBlockEntity;
+import appeng.blockentity.terminal.CraftingTerminalBlockEntity;
 import appeng.blockentity.terminal.TerminalBlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.neoforged.neoforge.registries.RegistryObject;
@@ -44,6 +45,11 @@ public final class AE2BlockEntities {
     public static final RegistryObject<BlockEntityType<TerminalBlockEntity>> TERMINAL =
         AE2Registries.BLOCK_ENTITIES.register("terminal",
             () -> BlockEntityType.Builder.of(TerminalBlockEntity::new, AE2Blocks.TERMINAL.get()).build(null));
+
+    public static final RegistryObject<BlockEntityType<CraftingTerminalBlockEntity>> CRAFTING_TERMINAL =
+        AE2Registries.BLOCK_ENTITIES.register("crafting_terminal",
+            () -> BlockEntityType.Builder.of(CraftingTerminalBlockEntity::new,
+                AE2Blocks.CRAFTING_TERMINAL.get()).build(null));
 
     private AE2BlockEntities() {}
 }

--- a/src/main/java/appeng/registry/AE2Blocks.java
+++ b/src/main/java/appeng/registry/AE2Blocks.java
@@ -15,6 +15,7 @@ import net.minecraft.world.level.material.MapColor;
 import net.neoforged.neoforge.registries.RegistryObject;
 
 import appeng.block.simple.DriveBlock;
+import appeng.block.terminal.CraftingTerminalBlock;
 import appeng.block.terminal.TerminalBlock;
 
 public final class AE2Blocks {
@@ -63,6 +64,9 @@ public final class AE2Blocks {
 
     public static final RegistryObject<Block> TERMINAL =
         AE2Registries.BLOCKS.register("terminal", TerminalBlock::new);
+
+    public static final RegistryObject<Block> CRAFTING_TERMINAL =
+        AE2Registries.BLOCKS.register("crafting_terminal", CraftingTerminalBlock::new);
 
     private AE2Blocks() {}
 }

--- a/src/main/java/appeng/registry/AE2Items.java
+++ b/src/main/java/appeng/registry/AE2Items.java
@@ -107,6 +107,10 @@ public final class AE2Items {
             "terminal",
             () -> new BlockItem(AE2Blocks.TERMINAL.get(), new Properties()));
 
+    public static final RegistryObject<Item> CRAFTING_TERMINAL = AE2Registries.ITEMS.register(
+            "crafting_terminal",
+            () -> new BlockItem(AE2Blocks.CRAFTING_TERMINAL.get(), new Properties()));
+
     public static final RegistryObject<Item> BASIC_CELL_1K = AE2Registries.ITEMS.register(
             "basic_cell_1k",
             () -> new BasicCell1kItem(new Properties().stacksTo(1)));

--- a/src/main/java/appeng/registry/AE2Menus.java
+++ b/src/main/java/appeng/registry/AE2Menus.java
@@ -3,6 +3,7 @@ package appeng.registry;
 import appeng.AE2Registries;
 import appeng.menu.ChargerMenu;
 import appeng.menu.InscriberMenu;
+import appeng.menu.terminal.CraftingTerminalMenu;
 import net.minecraft.world.inventory.MenuType;
 import net.neoforged.neoforge.registries.RegistryObject;
 
@@ -12,6 +13,9 @@ public final class AE2Menus {
 
     public static final RegistryObject<MenuType<ChargerMenu>> CHARGER_MENU =
         AE2Registries.MENUS.register("charger", () -> new MenuType<>(ChargerMenu::new));
+
+    public static final RegistryObject<MenuType<CraftingTerminalMenu>> CRAFTING_TERMINAL_MENU =
+        AE2Registries.MENUS.register("crafting_terminal", () -> CraftingTerminalMenu.TYPE);
 
     private AE2Menus() {}
 }


### PR DESCRIPTION
## Summary
- add a crafting terminal block and block entity that expose a persistent 3×3 matrix plus output slot
- create a crafting terminal menu and screen that provide crafting logic and UI on top of the ME terminal item listing
- register the new content and supply blockstate, model, recipe, and language assets for datagen

## Testing
- Not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e1df1b4e20832786789d55a006f1af