### PR TITLE
Add partitioned storage cells with whitelist enforcement

### DIFF
--- a/src/main/java/appeng/api/storage/cells/IBasicCellItem.java
+++ b/src/main/java/appeng/api/storage/cells/IBasicCellItem.java
@@ -31,6 +31,7 @@ import com.google.common.base.Preconditions;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.inventory.tooltip.TooltipComponent;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.resources.ResourceLocation;
 
 import appeng.api.storage.ItemStackView;
 import appeng.api.stacks.AEKey;
@@ -136,5 +137,12 @@ public interface IBasicCellItem extends ICellWorkbenchItem {
     default Optional<TooltipComponent> getCellTooltipImage(ItemStack is) {
         Preconditions.checkArgument(is.getItem() == this);
         return BasicCellHandler.INSTANCE.getTooltipImage(is);
+    }
+
+    /**
+     * @return The whitelist of items that this cell allows. An empty whitelist means the cell accepts all items.
+     */
+    default List<ResourceLocation> getWhitelist(ItemStack cellItem) {
+        return List.of();
     }
 }

--- a/src/main/java/appeng/datagen/AE2ItemModelProvider.java
+++ b/src/main/java/appeng/datagen/AE2ItemModelProvider.java
@@ -40,5 +40,6 @@ public class AE2ItemModelProvider extends ItemModelProvider {
         basicItem(AE2Items.BASIC_CELL_4K.get());
         basicItem(AE2Items.BASIC_CELL_16K.get());
         basicItem(AE2Items.BASIC_CELL_64K.get());
+        basicItem(AE2Items.PARTITIONED_CELL.get());
     }
 }

--- a/src/main/java/appeng/datagen/AE2LanguageProvider.java
+++ b/src/main/java/appeng/datagen/AE2LanguageProvider.java
@@ -42,6 +42,7 @@ public class AE2LanguageProvider extends LanguageProvider {
         add("item.appliedenergistics2.basic_cell_4k", "4k Storage Cell");
         add("item.appliedenergistics2.basic_cell_16k", "16k Storage Cell");
         add("item.appliedenergistics2.basic_cell_64k", "64k Storage Cell");
+        add("item.appliedenergistics2.partitioned_cell", "Partitioned Storage Cell");
         add("item.appliedenergistics2.fluid_storage_cell_1k", "1k Fluid Storage Cell");
         add("item.appliedenergistics2.fluid_storage_cell_4k", "4k Fluid Storage Cell");
         add("item.appliedenergistics2.fluid_storage_cell_16k", "16k Fluid Storage Cell");

--- a/src/main/java/appeng/datagen/AE2RecipeProvider.java
+++ b/src/main/java/appeng/datagen/AE2RecipeProvider.java
@@ -9,6 +9,7 @@ import net.minecraft.data.recipes.RecipeCategory;
 import net.minecraft.data.recipes.RecipeOutput;
 import net.minecraft.data.recipes.RecipeProvider;
 import net.minecraft.data.recipes.ShapedRecipeBuilder;
+import net.minecraft.data.recipes.ShapelessRecipeBuilder;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 
@@ -51,6 +52,12 @@ public class AE2RecipeProvider extends RecipeProvider {
                 .define('C', AE2Items.BASIC_CELL_16K.get())
                 .unlockedBy("has_basic_cell_16k", has(AE2Items.BASIC_CELL_16K.get()))
                 .save(output, new ResourceLocation(AE2Registries.MODID, "crafting/basic_cell_64k"));
+
+        ShapelessRecipeBuilder.shapeless(RecipeCategory.MISC, AE2Items.PARTITIONED_CELL.get())
+                .requires(AE2Items.ENGINEERING_PROCESSOR.get())
+                .requires(AE2Items.BASIC_CELL_1K.get())
+                .unlockedBy("has_basic_cell_1k", has(AE2Items.BASIC_CELL_1K.get()))
+                .save(output, new ResourceLocation(AE2Registries.MODID, "crafting/partitioned_cell"));
     }
 
     private static final class SkyStoneBrickRecipe implements FinishedRecipe {

--- a/src/main/java/appeng/items/storage/PartitionedCellItem.java
+++ b/src/main/java/appeng/items/storage/PartitionedCellItem.java
@@ -1,0 +1,113 @@
+package appeng.items.storage;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.StringTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+
+/**
+ * A basic 1k storage cell that restricts which items it can accept via a whitelist stored in NBT.
+ */
+public class PartitionedCellItem extends BasicCellItem {
+    private static final int CAPACITY = 1024;
+    private static final String CELL_TAG = "CellData";
+    private static final String WHITELIST_TAG = "Whitelist";
+
+    public PartitionedCellItem(Properties properties) {
+        super(properties, CAPACITY);
+    }
+
+    @Override
+    public List<ResourceLocation> getWhitelist(ItemStack cellItem) {
+        var whitelistTag = getWhitelistTag(cellItem, false);
+        if (whitelistTag == null || whitelistTag.isEmpty()) {
+            return List.of();
+        }
+
+        List<ResourceLocation> whitelist = new ArrayList<>(whitelistTag.size());
+        for (int i = 0; i < whitelistTag.size(); i++) {
+            var id = ResourceLocation.tryParse(whitelistTag.getString(i));
+            if (id != null) {
+                whitelist.add(id);
+            }
+        }
+        return whitelist;
+    }
+
+    public void setWhitelist(ItemStack cellItem, Collection<ResourceLocation> whitelist) {
+        if (whitelist.isEmpty()) {
+            clearWhitelist(cellItem);
+            return;
+        }
+
+        var tag = cellItem.getOrCreateTag();
+        CompoundTag cellTag;
+        if (tag.contains(CELL_TAG, Tag.TAG_COMPOUND)) {
+            cellTag = tag.getCompound(CELL_TAG);
+        } else {
+            cellTag = new CompoundTag();
+            tag.put(CELL_TAG, cellTag);
+        }
+
+        ListTag whitelistTag = new ListTag();
+        for (var id : whitelist) {
+            whitelistTag.add(StringTag.valueOf(id.toString()));
+        }
+        cellTag.put(WHITELIST_TAG, whitelistTag);
+    }
+
+    public void clearWhitelist(ItemStack cellItem) {
+        var tag = cellItem.getTag();
+        if (tag == null || !tag.contains(CELL_TAG, Tag.TAG_COMPOUND)) {
+            return;
+        }
+        var cellTag = tag.getCompound(CELL_TAG);
+        cellTag.remove(WHITELIST_TAG);
+        if (cellTag.isEmpty()) {
+            tag.remove(CELL_TAG);
+        }
+        if (tag.isEmpty()) {
+            cellItem.setTag(null);
+        }
+    }
+
+    private static ListTag getWhitelistTag(ItemStack cellItem, boolean create) {
+        CompoundTag tag = cellItem.getTag();
+        if (tag == null) {
+            if (!create) {
+                return null;
+            }
+            tag = new CompoundTag();
+            cellItem.setTag(tag);
+        }
+
+        CompoundTag cellTag;
+        if (tag.contains(CELL_TAG, Tag.TAG_COMPOUND)) {
+            cellTag = tag.getCompound(CELL_TAG);
+        } else {
+            if (!create) {
+                return null;
+            }
+            cellTag = new CompoundTag();
+            tag.put(CELL_TAG, cellTag);
+        }
+
+        if (cellTag.contains(WHITELIST_TAG, Tag.TAG_LIST)) {
+            return cellTag.getList(WHITELIST_TAG, Tag.TAG_STRING);
+        }
+
+        if (!create) {
+            return null;
+        }
+
+        ListTag whitelistTag = new ListTag();
+        cellTag.put(WHITELIST_TAG, whitelistTag);
+        return whitelistTag;
+    }
+}

--- a/src/main/java/appeng/registry/AE2Items.java
+++ b/src/main/java/appeng/registry/AE2Items.java
@@ -12,6 +12,7 @@ import appeng.items.storage.BasicCell16kItem;
 import appeng.items.storage.BasicCell1kItem;
 import appeng.items.storage.BasicCell4kItem;
 import appeng.items.storage.BasicCell64kItem;
+import appeng.items.storage.PartitionedCellItem;
 
 public final class AE2Items {
     public static final RegistryObject<Item> CERTUS_QUARTZ_CRYSTAL = AE2Registries.ITEMS.register(
@@ -140,6 +141,10 @@ public final class AE2Items {
     public static final RegistryObject<Item> BASIC_CELL_64K = AE2Registries.ITEMS.register(
             "basic_cell_64k",
             () -> new BasicCell64kItem(new Properties().stacksTo(1)));
+
+    public static final RegistryObject<Item> PARTITIONED_CELL = AE2Registries.ITEMS.register(
+            "partitioned_cell",
+            () -> new PartitionedCellItem(new Properties().stacksTo(1)));
 
     private AE2Items() {}
 }

--- a/src/main/java/appeng/storage/impl/ItemStorageChannel.java
+++ b/src/main/java/appeng/storage/impl/ItemStorageChannel.java
@@ -29,6 +29,10 @@ public class ItemStorageChannel implements IItemStorageChannel {
 
         var gridId = service.getGridId();
         if (gridId != null) {
+            if (!StorageService.isItemAllowedByWhitelist(gridId, stack.getItem())) {
+                StorageService.logPartitionedInsert(gridId, stack.getItem(), simulate);
+                return stack;
+            }
             int accepted = StorageService.insertIntoNetwork(gridId, stack.getItem(), stack.getCount(), simulate);
             stack.shrink(accepted);
             return stack.isEmpty() ? ItemStack.EMPTY : stack;
@@ -84,6 +88,10 @@ public class ItemStorageChannel implements IItemStorageChannel {
 
         var gridId = service.getGridId();
         if (gridId != null) {
+            if (!StorageService.isItemAllowedByWhitelist(gridId, resource.getItem())) {
+                StorageService.logPartitionedInsert(gridId, resource.getItem(), simulate);
+                return 0;
+            }
             long inserted = 0;
             long remaining = amount;
             while (remaining > 0) {


### PR DESCRIPTION
## Summary
- add a partitioned storage cell item that persists its whitelist in NBT and register it for use
- extend the basic cell API and network storage logic to honor whitelists and log rejected insertions
- generate datagen assets for the partitioned cell, including recipe, model, and localization

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e205f2e5bc8327a4848c311a2ab2bd