### PR TITLE
Implement bus transfer logic for Phase 2 PR-19

### DIFF
--- a/src/main/java/appeng/blockentity/io/ExportBusBlockEntity.java
+++ b/src/main/java/appeng/blockentity/io/ExportBusBlockEntity.java
@@ -1,22 +1,34 @@
 package appeng.blockentity.io;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 
+import appeng.api.behaviors.StackExportStrategy;
 import appeng.api.config.FuzzyMode;
 import appeng.api.config.RedstoneMode;
 import appeng.api.config.SchedulingMode;
 import appeng.api.config.Settings;
 import appeng.api.config.YesNo;
 import appeng.api.networking.IGridNode;
+import appeng.api.networking.IGrid;
 import appeng.api.networking.ticking.IGridTickable;
 import appeng.api.networking.ticking.TickRateModulation;
 import appeng.api.networking.ticking.TickingRequest;
 import appeng.api.util.IConfigManager;
+import appeng.api.stacks.AEKey;
 import appeng.core.settings.TickRates;
+import appeng.core.definitions.AEItems;
+import appeng.parts.automation.StackTransferContextImpl;
+import appeng.parts.automation.StackWorldBehaviors;
 
 public class ExportBusBlockEntity extends IOBusBlockEntity implements IGridTickable {
+
+    private StackExportStrategy exportStrategy;
+    private int nextSlot = 0;
 
     public ExportBusBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
         super(type, pos, state);
@@ -41,6 +53,105 @@ public class ExportBusBlockEntity extends IOBusBlockEntity implements IGridTicka
 
     @Override
     public TickRateModulation tickingRequest(IGridNode node, int ticksSinceLastCall) {
-        return TickRateModulation.SLEEP;
+        if (!canDoBusWork()) {
+            return TickRateModulation.SLEEP;
+        }
+
+        if (getConfigManager().getSetting(Settings.CRAFT_ONLY) == YesNo.YES) {
+            return TickRateModulation.SLOWER;
+        }
+
+        IGrid grid = node.getGrid();
+        if (grid == null) {
+            return TickRateModulation.SLEEP;
+        }
+
+        var strategy = getExportStrategy();
+        if (strategy == null) {
+            return TickRateModulation.SLOWER;
+        }
+
+        var context = new StackTransferContextImpl(
+                grid.getStorageService(),
+                grid.getEnergyService(),
+                source,
+                getOperationsPerTick(),
+                getFilterList());
+
+        context.setInverted(isUpgradedWith(AEItems.INVERTER_CARD));
+
+        var schedulingMode = getConfigManager().getSetting(Settings.SCHEDULING_MODE);
+        var totalSlots = getAvailableConfigSlots();
+        var iterations = 0;
+        var didWork = false;
+
+        for (; iterations < totalSlots && context.hasOperationsLeft(); iterations++) {
+            int slotIndex = selectSlot(schedulingMode, iterations, totalSlots);
+            AEKey what = getConfig().getKey(slotIndex);
+            if (what == null) {
+                continue;
+            }
+
+            long transferFactor = what.getAmountPerOperation();
+            long requestedAmount = (long) context.getOperationsRemaining() * transferFactor;
+            long inserted = strategy.transfer(context, what, requestedAmount);
+
+            if (inserted > 0) {
+                didWork = true;
+                long operationsUsed = Math.max(1, (inserted + transferFactor - 1) / transferFactor);
+                context.reduceOperationsRemaining(operationsUsed);
+            }
+        }
+
+        if (didWork) {
+            advanceScheduling(schedulingMode, iterations, totalSlots);
+        }
+
+        return didWork ? TickRateModulation.FASTER : TickRateModulation.SLOWER;
+    }
+
+    @Override
+    protected void onTargetChanged() {
+        super.onTargetChanged();
+        exportStrategy = null;
+    }
+
+    @Override
+    public void saveAdditional(CompoundTag data, HolderLookup.Provider registries) {
+        super.saveAdditional(data, registries);
+        data.putInt("nextSlot", nextSlot);
+    }
+
+    @Override
+    public void loadTag(CompoundTag data, HolderLookup.Provider registries) {
+        super.loadTag(data, registries);
+        nextSlot = data.getInt("nextSlot");
+    }
+
+    private StackExportStrategy getExportStrategy() {
+        if (exportStrategy == null) {
+            var level = getLevel();
+            if (level instanceof ServerLevel serverLevel) {
+                var fromPos = getBlockPos().relative(getFront());
+                var fromSide = getFront().getOpposite();
+                exportStrategy = StackWorldBehaviors.createExportFacade(serverLevel, fromPos, fromSide);
+            }
+        }
+
+        return exportStrategy;
+    }
+
+    private int selectSlot(SchedulingMode mode, int iteration, int totalSlots) {
+        return switch (mode) {
+            case RANDOM -> getLevel().getRandom().nextInt(totalSlots);
+            case ROUNDROBIN -> (nextSlot + iteration) % totalSlots;
+            case DEFAULT -> iteration;
+        };
+    }
+
+    private void advanceScheduling(SchedulingMode mode, int iterations, int totalSlots) {
+        if (mode == SchedulingMode.ROUNDROBIN && totalSlots > 0) {
+            nextSlot = (nextSlot + iterations) % totalSlots;
+        }
     }
 }

--- a/src/main/java/appeng/blockentity/io/ImportBusBlockEntity.java
+++ b/src/main/java/appeng/blockentity/io/ImportBusBlockEntity.java
@@ -1,6 +1,7 @@
 package appeng.blockentity.io;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 
@@ -8,9 +9,16 @@ import appeng.api.networking.IGridNode;
 import appeng.api.networking.ticking.IGridTickable;
 import appeng.api.networking.ticking.TickRateModulation;
 import appeng.api.networking.ticking.TickingRequest;
+import appeng.api.networking.IGrid;
 import appeng.core.settings.TickRates;
+import appeng.api.behaviors.StackImportStrategy;
+import appeng.parts.automation.StackTransferContextImpl;
+import appeng.parts.automation.StackWorldBehaviors;
+import appeng.core.definitions.AEItems;
 
 public class ImportBusBlockEntity extends IOBusBlockEntity implements IGridTickable {
+
+    private StackImportStrategy importStrategy;
 
     public ImportBusBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
         super(type, pos, state);
@@ -25,6 +33,50 @@ public class ImportBusBlockEntity extends IOBusBlockEntity implements IGridTicka
 
     @Override
     public TickRateModulation tickingRequest(IGridNode node, int ticksSinceLastCall) {
-        return TickRateModulation.SLEEP;
+        if (!canDoBusWork()) {
+            return TickRateModulation.SLEEP;
+        }
+
+        IGrid grid = node.getGrid();
+        if (grid == null) {
+            return TickRateModulation.SLEEP;
+        }
+
+        var strategy = getImportStrategy();
+        if (strategy == null) {
+            return TickRateModulation.SLOWER;
+        }
+
+        var context = new StackTransferContextImpl(
+                grid.getStorageService(),
+                grid.getEnergyService(),
+                source,
+                getOperationsPerTick(),
+                getFilterList());
+
+        context.setInverted(isUpgradedWith(AEItems.INVERTER_CARD));
+
+        strategy.transfer(context);
+
+        return context.hasDoneWork() ? TickRateModulation.FASTER : TickRateModulation.SLOWER;
+    }
+
+    @Override
+    protected void onTargetChanged() {
+        super.onTargetChanged();
+        importStrategy = null;
+    }
+
+    private StackImportStrategy getImportStrategy() {
+        if (importStrategy == null) {
+            var level = getLevel();
+            if (level instanceof ServerLevel serverLevel) {
+                var fromPos = getBlockPos().relative(getFront());
+                var fromSide = getFront().getOpposite();
+                importStrategy = StackWorldBehaviors.createImportFacade(serverLevel, fromPos, fromSide, type -> true);
+            }
+        }
+
+        return importStrategy;
     }
 }

--- a/src/main/java/appeng/blockentity/storage/StorageBusBlockEntity.java
+++ b/src/main/java/appeng/blockentity/storage/StorageBusBlockEntity.java
@@ -1,5 +1,7 @@
 package appeng.blockentity.storage;
 
+import java.util.IdentityHashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import org.jetbrains.annotations.Nullable;
@@ -12,28 +14,42 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.core.Direction;
+import net.minecraft.server.level.ServerLevel;
 
 import appeng.api.config.AccessRestriction;
 import appeng.api.config.FuzzyMode;
+import appeng.api.config.IncludeExclude;
 import appeng.api.config.Setting;
 import appeng.api.config.Settings;
 import appeng.api.config.StorageFilter;
 import appeng.api.config.YesNo;
 import appeng.api.orientation.BlockOrientation;
+import appeng.api.networking.GridFlags;
+import appeng.api.stacks.AEKeyType;
 import appeng.api.storage.IStorageMounts;
 import appeng.api.storage.IStorageProvider;
 import appeng.api.storage.StorageApi;
+import appeng.api.storage.MEStorage;
+import appeng.api.behaviors.ExternalStorageStrategy;
 import appeng.api.util.IConfigManager;
 import appeng.api.util.IConfigurableObject;
 import appeng.blockentity.grid.AENetworkedBlockEntity;
 import appeng.helpers.IConfigInvHost;
 import appeng.helpers.IPriorityHost;
 import appeng.core.definitions.AEBlocks;
+import appeng.core.AELog;
 import appeng.menu.ISubMenu;
 import appeng.menu.MenuOpener;
 import appeng.menu.implementations.StorageBusBlockMenu;
 import appeng.menu.locator.MenuLocators;
 import appeng.util.ConfigInventory;
+import appeng.util.prioritylist.IPartitionList;
+import appeng.me.storage.MEInventoryHandler;
+import appeng.me.storage.NullInventory;
+import appeng.me.storage.CompositeStorage;
+import appeng.core.definitions.AEItems;
+import appeng.parts.automation.StackWorldBehaviors;
 
 public class StorageBusBlockEntity extends AENetworkedBlockEntity
         implements IStorageProvider, IConfigInvHost, IPriorityHost, IConfigurableObject {
@@ -51,6 +67,7 @@ public class StorageBusBlockEntity extends AENetworkedBlockEntity
     public StorageBusBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
         super(type, pos, state);
 
+        getMainNode().setFlags(GridFlags.REQUIRE_CHANNEL);
         getMainNode().addService(IStorageProvider.class, this);
     }
 
@@ -80,6 +97,8 @@ public class StorageBusBlockEntity extends AENetworkedBlockEntity
         IStorageProvider.requestUpdate(getMainNode());
     }
 
+    private final MEInventoryHandler handler = new MEInventoryHandler(NullInventory.of());
+
     @Override
     public void mountInventories(IStorageMounts storageMounts) {
         var level = getLevel();
@@ -87,11 +106,103 @@ public class StorageBusBlockEntity extends AENetworkedBlockEntity
             return;
         }
 
+        updateMountedStorage();
+
+        if (!(handler.getDelegate() instanceof NullInventory)) {
+            storageMounts.mount(handler, getPriority());
+        }
+    }
+
+    private void updateMountedStorage() {
+        var level = getLevel();
+        if (level == null) {
+            handler.setDelegate(NullInventory.of());
+            return;
+        }
+
         var front = getFront();
         var targetPos = getBlockPos().relative(front);
-        StorageApi.INSTANCE.findStorage(level, targetPos, front.getOpposite()).ifPresent(storage -> {
-            storageMounts.mount(storage, getPriority());
+
+        MEStorage newDelegate;
+        if (level instanceof ServerLevel serverLevel) {
+            newDelegate = StorageApi.INSTANCE
+                    .findStorage(level, targetPos, front.getOpposite())
+                    .orElseGet(() -> createExternalComposite(serverLevel, targetPos, front));
+        } else {
+            newDelegate = StorageApi.INSTANCE
+                    .findStorage(level, targetPos, front.getOpposite())
+                    .orElse(null);
+        }
+
+        if (newDelegate == null) {
+            newDelegate = NullInventory.of();
+        }
+
+        handler.setDelegate(newDelegate);
+
+        if (newDelegate instanceof NullInventory) {
+            AELog.debug("Storage bus at {} has no adjacent storage to mount", getBlockPos());
+        } else {
+            var description = newDelegate.getDescription();
+            AELog.debug("Storage bus at {} mounted {}", getBlockPos(),
+                    description != null ? description.getString() : newDelegate);
+        }
+
+        var access = getConfigManager().getSetting(Settings.ACCESS);
+        handler.setAllowExtraction(access.isAllowExtraction());
+        handler.setAllowInsertion(access.isAllowInsertion());
+
+        handler.setWhitelist(isUpgradedWith(AEItems.INVERTER_CARD) ? IncludeExclude.BLACKLIST : IncludeExclude.WHITELIST);
+        handler.setPartitionList(createFilter());
+
+        var filterOnExtract = getConfigManager().getSetting(Settings.FILTER_ON_EXTRACT) == YesNo.YES;
+        var extractableOnly = getConfigManager().getSetting(Settings.STORAGE_FILTER) == StorageFilter.EXTRACTABLE_ONLY;
+        handler.setExtractFiltering(filterOnExtract, extractableOnly && filterOnExtract);
+        handler.setVoidOverflow(isUpgradedWith(AEItems.VOID_CARD));
+    }
+
+    private MEStorage createExternalComposite(ServerLevel level, BlockPos targetPos, Direction front) {
+        Map<AEKeyType, ExternalStorageStrategy> strategies = StackWorldBehaviors
+                .createExternalStorageStrategies(level, targetPos, front.getOpposite());
+
+        if (strategies.isEmpty()) {
+            return NullInventory.of();
+        }
+
+        var storages = new IdentityHashMap<AEKeyType, MEStorage>(strategies.size());
+        var extractableOnly = getConfigManager().getSetting(Settings.STORAGE_FILTER) == StorageFilter.EXTRACTABLE_ONLY;
+
+        strategies.forEach((type, strategy) -> {
+            var wrapper = strategy.createWrapper(extractableOnly, this::onExternalStorageChanged);
+            if (wrapper != null) {
+                storages.put(type, wrapper);
+            }
         });
+
+        if (storages.isEmpty()) {
+            return NullInventory.of();
+        }
+
+        return new CompositeStorage(storages);
+    }
+
+    private void onExternalStorageChanged() {
+        IStorageProvider.requestUpdate(getMainNode());
+    }
+
+    private IPartitionList createFilter() {
+        var builder = IPartitionList.builder();
+
+        if (isUpgradedWith(AEItems.FUZZY_CARD)) {
+            builder.fuzzyMode(getConfigManager().getSetting(Settings.FUZZY_MODE));
+        }
+
+        int slotsToUse = Math.min(config.size(), 18 + getUpgrades().getInstalledUpgrades(AEItems.CAPACITY_CARD) * 9);
+        for (int i = 0; i < slotsToUse; i++) {
+            builder.add(config.getKey(i));
+        }
+
+        return builder.build();
     }
 
     @Override

--- a/src/main/java/appeng/parts/automation/StackTransferContextImpl.java
+++ b/src/main/java/appeng/parts/automation/StackTransferContextImpl.java
@@ -16,7 +16,7 @@ import appeng.util.prioritylist.IPartitionList;
 /**
  * Context for stack transfer operations, regardless of whether they occur in or out of the network.
  */
-class StackTransferContextImpl implements StackTransferContext {
+public class StackTransferContextImpl implements StackTransferContext {
     private final IStorageService internalStorage;
     private final IEnergySource energySource;
     private final IActionSource actionSource;

--- a/src/main/java/appeng/parts/automation/StorageImportStrategy.java
+++ b/src/main/java/appeng/parts/automation/StorageImportStrategy.java
@@ -19,6 +19,8 @@ import appeng.core.AELog;
 public class StorageImportStrategy<T, S> implements StackImportStrategy {
     private final BlockCapabilityCache<T, Direction> cache;
     private final HandlerStrategy<T, S> conversion;
+    private final BlockPos busPos;
+    private final BlockPos targetPos;
 
     public StorageImportStrategy(BlockCapability<T, Direction> capability,
             HandlerStrategy<T, S> conversion,
@@ -27,6 +29,8 @@ public class StorageImportStrategy<T, S> implements StackImportStrategy {
             Direction fromSide) {
         this.cache = BlockCapabilityCache.create(capability, level, fromPos, fromSide);
         this.conversion = conversion;
+        this.targetPos = fromPos;
+        this.busPos = fromPos.relative(fromSide);
     }
 
     @Override
@@ -83,6 +87,10 @@ public class StorageImportStrategy<T, S> implements StackImportStrategy {
                 var opsUsed = Math.max(1, inserted / conversion.getKeyType().getAmountPerOperation());
                 context.reduceOperationsRemaining(opsUsed);
                 remainingTransferAmount -= inserted;
+
+                if (inserted > 0) {
+                    AELog.debug("Import bus at {} pulled {}x{} from {}", busPos, inserted, resource.what(), targetPos);
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- mount adjacent inventories through the storage bus with filter-aware ME wrappers and logging
- enable import and export bus block entities to move filtered stacks using shared transfer context helpers
- ensure bus block entities integrate with the grid, respect redstone and scheduling, and record transfer activity

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e2b5d317508327bc3be36646ac1bae