### PR TITLE
PR-31: Generic machine executors and blast furnace integration

### DIFF
--- a/src/main/java/appeng/api/integration/machines/AbstractProcessingMachine.java
+++ b/src/main/java/appeng/api/integration/machines/AbstractProcessingMachine.java
@@ -1,12 +1,23 @@
 package appeng.api.integration.machines;
 
+import java.util.UUID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.ItemStack;
+
 import appeng.crafting.CraftingJob;
+import appeng.integration.processing.ProcessingTransferHandler;
+import appeng.storage.impl.StorageService;
 
 /**
- * Base implementation that tracks a single running job. Concrete machines can extend this to reuse common lifecycle
- * handling.
+ * Base implementation that provides the shared execution lifecycle for external processing machines.
  */
 public abstract class AbstractProcessingMachine implements IProcessingMachine {
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractProcessingMachine.class);
+
     private boolean busy;
 
     @Override
@@ -19,6 +30,45 @@ public abstract class AbstractProcessingMachine implements IProcessingMachine {
         return !busy && IProcessingMachine.super.canProcess(job);
     }
 
+    /**
+     * Executes the provided job using the machine specific hooks implemented by the subclass.
+     */
+    public final boolean execute(CraftingJob job) {
+        var transfer = new ProcessingTransferHandler(job, this);
+
+        LOG.debug(Component.translatable(getStartTranslationKey(), job.describeOutputs()).getString());
+
+        boolean success = false;
+        try {
+            beginProcessing(job);
+            acceptInputs(job, transfer);
+
+            int ticks = Math.max(runMachine(job), CraftingJob.DEFAULT_TICKS_REQUIRED);
+            job.setTicksRequired(ticks);
+            job.setTicksCompleted(ticks);
+
+            provideOutputs(job, transfer);
+            job.recordOutputDelivery(transfer.getInsertedOutputs(), transfer.getDroppedOutputs());
+            success = true;
+
+            LOG.debug(Component.translatable(getCompleteTranslationKey(), job.describeOutputs()).getString());
+            return true;
+        } catch (Exception e) {
+            LOG.debug(Component.translatable(getFailedTranslationKey(), job.describeOutputs()).getString(), e);
+            transfer.rollback();
+            return false;
+        } finally {
+            if (success) {
+                transfer.clearTrackedInputs();
+            }
+            try {
+                finishProcessing(job);
+            } catch (Exception e) {
+                LOG.debug("Error while finishing external machine execution for job {} using {}", job.getId(), this, e);
+            }
+        }
+    }
+
     @Override
     public void beginProcessing(CraftingJob job) {
         busy = true;
@@ -27,5 +77,144 @@ public abstract class AbstractProcessingMachine implements IProcessingMachine {
     @Override
     public void finishProcessing(CraftingJob job) {
         busy = false;
+    }
+
+    /**
+     * {@return the translation key used when logging that execution has started.}
+     */
+    protected abstract String getStartTranslationKey();
+
+    /**
+     * {@return the translation key used when logging that execution completed successfully.}
+     */
+    protected abstract String getCompleteTranslationKey();
+
+    /**
+     * {@return the translation key used when logging that execution failed.}
+     */
+    protected abstract String getFailedTranslationKey();
+
+    /**
+     * {@return the grid id the machine should interact with.}
+     */
+    public abstract UUID getGridId();
+
+    /**
+     * Allows the subclass to perform its processing logic and return the number of ticks consumed.
+     */
+    protected abstract int runMachine(CraftingJob job);
+
+    /**
+     * Inserts the provided stack into the backing machine, returning any remainder.
+     */
+    protected abstract ItemStack insertInput(ItemStack stack);
+
+    /**
+     * Releases any staged inputs back to the network, typically as part of rollback handling.
+     */
+    protected abstract ItemStack releaseInput();
+
+    /**
+     * Extracts the prepared outputs from the backing machine.
+     */
+    protected abstract ItemStack extractOutput(ItemStack requested);
+
+    /**
+     * Called when the machine needs to drop an item into the world (typically overflow).
+     */
+    protected abstract void dropItem(ItemStack stack);
+
+    /**
+     * Extracts the requested stack from the ME network.
+     */
+    public final ItemStack withdrawFromNetwork(ItemStack stack, CraftingJob job) {
+        if (stack.isEmpty()) {
+            return ItemStack.EMPTY;
+        }
+
+        UUID gridId = getGridId();
+        if (gridId == null) {
+            throw new IllegalStateException("Machine has no grid binding for job " + job.getId());
+        }
+
+        int requested = Math.max(stack.getCount(), 1);
+        int extracted = StorageService.extractFromNetwork(gridId, stack.getItem(), requested, false);
+        if (extracted <= 0) {
+            throw new IllegalStateException("Unable to extract " + stack + " from network for job " + job.getId());
+        }
+        if (extracted < requested) {
+            StorageService.insertIntoNetwork(gridId, stack.getItem(), extracted, false);
+            throw new IllegalStateException("Insufficient items available for job " + job.getId());
+        }
+
+        ItemStack delivered = stack.copy();
+        delivered.setCount(extracted);
+        return delivered;
+    }
+
+    /**
+     * Reinserts the provided stack into the ME network.
+     */
+    public final void returnToNetwork(ItemStack stack) {
+        if (stack.isEmpty()) {
+            return;
+        }
+
+        UUID gridId = getGridId();
+        if (gridId == null) {
+            return;
+        }
+
+        StorageService.insertIntoNetwork(gridId, stack.getItem(), stack.getCount(), false);
+    }
+
+    /**
+     * Inserts the produced outputs into the ME network, returning the number of items accepted.
+     */
+    public final int insertOutputsIntoNetwork(ItemStack stack) {
+        if (stack.isEmpty()) {
+            return 0;
+        }
+
+        UUID gridId = getGridId();
+        if (gridId == null) {
+            return 0;
+        }
+
+        return StorageService.insertIntoNetwork(gridId, stack.getItem(), stack.getCount(), false);
+    }
+
+    /**
+     * Delivers an extracted stack into the backing machine.
+     */
+    public final ItemStack deliverInputToMachine(ItemStack stack) {
+        if (stack.isEmpty()) {
+            return ItemStack.EMPTY;
+        }
+        return insertInput(stack);
+    }
+
+    /**
+     * Releases staged inputs from the machine.
+     */
+    public final ItemStack releaseInputsFromMachine() {
+        return releaseInput();
+    }
+
+    /**
+     * Retrieves the prepared outputs from the machine.
+     */
+    public final ItemStack retrieveOutputFromMachine(ItemStack requested) {
+        return extractOutput(requested);
+    }
+
+    /**
+     * Handles overflow by delegating to the machine drop behaviour.
+     */
+    public final void handleOverflow(ItemStack stack) {
+        if (stack.isEmpty()) {
+            return;
+        }
+        dropItem(stack);
     }
 }

--- a/src/main/java/appeng/crafting/CraftingJobManager.java
+++ b/src/main/java/appeng/crafting/CraftingJobManager.java
@@ -110,6 +110,8 @@ public final class CraftingJobManager {
         LOG.debug(Component.translatable("message.appliedenergistics2.processing_job.external_attempt",
                 job.describeOutputs()).getString());
 
+        LOG.debug("Routing processing job {} to external machine {}", job.getId(), machine.get());
+
         var handled = ProcessingMachineExecutor.tryExecute(job, machine.get());
         if (handled) {
             jobMachines.put(job.getId(), machine.get());

--- a/src/main/java/appeng/datagen/AE2LanguageProvider.java
+++ b/src/main/java/appeng/datagen/AE2LanguageProvider.java
@@ -69,6 +69,12 @@ public class AE2LanguageProvider extends LanguageProvider {
                 "External Furnace Execution Complete: %s");
         add("message.appliedenergistics2.processing_job.external_furnace_failed",
                 "External Furnace Execution Failed: %s");
+        add("message.appliedenergistics2.processing_job.external_blast_furnace_started",
+                "External Blast Furnace Execution Started: %s");
+        add("message.appliedenergistics2.processing_job.external_blast_furnace_complete",
+                "External Blast Furnace Execution Complete: %s");
+        add("message.appliedenergistics2.processing_job.external_blast_furnace_failed",
+                "External Blast Furnace Execution Failed: %s");
         add("gui.appliedenergistics2.pattern_encoding.mode.crafting", "Crafting Pattern");
         add("gui.appliedenergistics2.pattern_encoding.mode.processing", "Processing Pattern");
         add("gui.appliedenergistics2.pattern_encoding.mode_toggle_hint", "Click to switch pattern type.");

--- a/src/main/java/appeng/integration/processing/BlastFurnaceProcessingMachine.java
+++ b/src/main/java/appeng/integration/processing/BlastFurnaceProcessingMachine.java
@@ -1,0 +1,49 @@
+package appeng.integration.processing;
+
+import java.util.UUID;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.item.crafting.AbstractCookingRecipe;
+import net.minecraft.world.item.crafting.RecipeType;
+import net.minecraft.world.level.block.entity.AbstractFurnaceBlockEntity;
+import net.minecraft.world.level.block.entity.BlastFurnaceBlockEntity;
+
+/**
+ * Processing machine wrapper for the vanilla blast furnace.
+ */
+public class BlastFurnaceProcessingMachine extends FurnaceProcessingMachine {
+    public BlastFurnaceProcessingMachine(ServerLevel level, BlockPos furnacePos, UUID gridId) {
+        super(level, furnacePos, gridId);
+    }
+
+    @Override
+    protected RecipeType<? extends AbstractCookingRecipe> getRecipeType() {
+        return RecipeType.BLASTING;
+    }
+
+    @Override
+    protected boolean isValidFurnace(AbstractFurnaceBlockEntity furnace) {
+        return furnace instanceof BlastFurnaceBlockEntity;
+    }
+
+    @Override
+    protected String getStartTranslationKey() {
+        return "message.appliedenergistics2.processing_job.external_blast_furnace_started";
+    }
+
+    @Override
+    protected String getCompleteTranslationKey() {
+        return "message.appliedenergistics2.processing_job.external_blast_furnace_complete";
+    }
+
+    @Override
+    protected String getFailedTranslationKey() {
+        return "message.appliedenergistics2.processing_job.external_blast_furnace_failed";
+    }
+
+    @Override
+    public String toString() {
+        return "BlastFurnaceProcessingMachine{" + getLevel().dimension().location() + "@" + getFurnacePos() + "}";
+    }
+}

--- a/src/main/java/appeng/integration/processing/ProcessingMachineExecutor.java
+++ b/src/main/java/appeng/integration/processing/ProcessingMachineExecutor.java
@@ -3,11 +3,9 @@ package appeng.integration.processing;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import net.minecraft.network.chat.Component;
-
+import appeng.api.integration.machines.AbstractProcessingMachine;
 import appeng.api.integration.machines.IProcessingMachine;
 import appeng.crafting.CraftingJob;
-import appeng.integration.processing.FurnaceProcessingMachine;
 
 /**
  * Coordinates the stub execution flow when routing processing jobs to external machines.
@@ -23,61 +21,11 @@ public final class ProcessingMachineExecutor {
             return false;
         }
 
-        if (machine instanceof FurnaceProcessingMachine furnace) {
-            LOG.debug(Component
-                    .translatable("message.appliedenergistics2.processing_job.external_furnace_started",
-                            job.describeOutputs())
-                    .getString());
-            var transfer = new ProcessingTransferHandler(job, machine);
-            boolean success = false;
-            try {
-                machine.beginProcessing(job);
-                machine.acceptInputs(job, transfer);
-
-                int ticks = furnace.process(job);
-                job.setTicksRequired(Math.max(ticks, 1));
-                job.setTicksCompleted(job.getTicksRequired());
-
-                machine.provideOutputs(job, transfer);
-                job.recordOutputDelivery(transfer.getInsertedOutputs(), transfer.getDroppedOutputs());
-                success = true;
-                LOG.debug(Component
-                        .translatable("message.appliedenergistics2.processing_job.external_furnace_complete",
-                                job.describeOutputs())
-                        .getString());
-                return true;
-            } catch (Exception e) {
-                LOG.debug(Component
-                        .translatable("message.appliedenergistics2.processing_job.external_furnace_failed",
-                                job.describeOutputs())
-                        .getString(), e);
-                transfer.rollback();
-                return false;
-            } finally {
-                if (success) {
-                    transfer.clearTrackedInputs();
-                }
-                try {
-                    machine.finishProcessing(job);
-                } catch (Exception e) {
-                    LOG.debug("Error while finishing external furnace execution for job {}", job.getId(), e);
-                }
-            }
+        if (machine instanceof AbstractProcessingMachine abstractMachine) {
+            return abstractMachine.execute(job);
         }
 
         LOG.debug("Stub external machine executor invoked for job {} using {}", job.getId(), machine);
-
-        var transfer = new ProcessingTransferHandler(job, machine);
-        try {
-            machine.beginProcessing(job);
-            machine.acceptInputs(job, transfer);
-            machine.provideOutputs(job, transfer);
-        } catch (Exception e) {
-            LOG.debug("Stub execution encountered an error for job {}", job.getId(), e);
-            return false;
-        } finally {
-            machine.finishProcessing(job);
-        }
 
         LOG.debug("Stub execution for job {} completed with no action; falling back to assembler.", job.getId());
         return false;

--- a/src/main/java/appeng/parts/automation/IOBusPart.java
+++ b/src/main/java/appeng/parts/automation/IOBusPart.java
@@ -35,6 +35,7 @@ import java.util.UUID;
 
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.AbstractFurnaceBlockEntity;
+import net.minecraft.world.level.block.entity.BlastFurnaceBlockEntity;
 import net.minecraft.world.phys.Vec3;
 
 import appeng.api.config.FuzzyMode;
@@ -61,6 +62,7 @@ import appeng.core.settings.TickRates;
 import appeng.helpers.IConfigInvHost;
 import appeng.items.parts.PartModels;
 import appeng.me.helpers.MachineSource;
+import appeng.integration.processing.BlastFurnaceProcessingMachine;
 import appeng.integration.processing.FurnaceProcessingMachine;
 import appeng.integration.processing.ProcessingMachineRegistry;
 import appeng.menu.ISubMenu;
@@ -338,6 +340,12 @@ public abstract class IOBusPart extends UpgradeablePart implements IGridTickable
         IProcessingMachine machine = null;
         if (neighbor instanceof IProcessingMachine processingMachine) {
             machine = processingMachine;
+        } else if (neighbor instanceof BlastFurnaceBlockEntity) {
+            var node = getMainNode().getNode();
+            UUID gridId = node != null ? node.getGridId() : null;
+            if (gridId != null) {
+                machine = new BlastFurnaceProcessingMachine(serverLevel, targetPos, gridId);
+            }
         } else if (neighbor instanceof AbstractFurnaceBlockEntity) {
             var node = getMainNode().getNode();
             UUID gridId = node != null ? node.getGridId() : null;


### PR DESCRIPTION
## Summary
- introduce a reusable `AbstractProcessingMachine` lifecycle with rollback-aware transfer handling
- refactor the furnace executor to use the shared flow and support configurable furnace subtypes
- add a blast furnace processing machine, expose it via IO bus discovery, and document the new status messages

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e3274870b88327ae6f93adf8583afc