### PR TITLE
Add shared offline overlays and terminal search hints

### DIFF
--- a/src/generated/resources/assets/ae2/lang/en_us.json
+++ b/src/generated/resources/assets/ae2/lang/en_us.json
@@ -335,6 +335,7 @@
   "gui.appliedenergistics2.pattern_encoding.mode_toggle_hint": "Click to switch pattern type.",
   "gui.appliedenergistics2.crafting_job.dependencies": "Dependencies",
   "gui.appliedenergistics2.terminal.search": "Search Items",
+  "gui.appliedenergistics2.terminal.search_hint": "Type to filter stored items",
   "gui.appliedenergistics2.redstone.button": "RS",
   "gui.appliedenergistics2.redstone.mode.always_active": "Always active",
   "gui.appliedenergistics2.redstone.mode.active_with_signal": "Active with redstone signal",

--- a/src/main/java/appeng/client/gui/OfflineOverlayRenderer.java
+++ b/src/main/java/appeng/client/gui/OfflineOverlayRenderer.java
@@ -4,6 +4,8 @@ import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
 
+import appeng.grid.SimpleGridNode.OfflineReason;
+
 /**
  * Renders the common offline overlay that is used across multiple AE2 screens. Centralizing the
  * rendering keeps the tint, text color and alignment consistent between terminals, monitors and
@@ -36,5 +38,18 @@ public final class OfflineOverlayRenderer {
         int textX = x + (width - textWidth) / 2;
         int textY = y + (height - font.lineHeight) / 2;
         graphics.drawString(font, message, textX, textY, TEXT_COLOR, false);
+    }
+
+    public static void renderForReason(GuiGraphics graphics, Font font, OfflineReason reason, int x, int y, int width,
+            int height) {
+        renderWithMessage(graphics, font, getMessageForReason(reason), x, y, width, height);
+    }
+
+    public static Component getMessageForReason(OfflineReason reason) {
+        return switch (reason) {
+            case REDSTONE -> Component.translatable("gui.appliedenergistics2.offline.redstone");
+            case CHANNELS -> Component.translatable("gui.appliedenergistics2.offline.channels");
+            case NONE -> Component.translatable("gui.appliedenergistics2.offline.power");
+        };
     }
 }

--- a/src/main/java/appeng/client/screen/CraftingTerminalScreen.java
+++ b/src/main/java/appeng/client/screen/CraftingTerminalScreen.java
@@ -5,7 +5,6 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Inventory;
 
 import appeng.client.gui.OfflineOverlayRenderer;
-import appeng.core.localization.InGameTooltip;
 import appeng.menu.terminal.CraftingTerminalMenu;
 
 public class CraftingTerminalScreen extends TerminalScreen {
@@ -57,7 +56,7 @@ public class CraftingTerminalScreen extends TerminalScreen {
     private void renderGridOfflineOverlay(GuiGraphics graphics) {
         int left = this.leftPos + GRID_LEFT_OFFSET;
         int top = this.topPos + GRID_TOP_OFFSET;
-        OfflineOverlayRenderer.renderWithMessage(graphics, this.font, InGameTooltip.DeviceOffline.text(), left, top,
+        OfflineOverlayRenderer.renderForReason(graphics, this.font, this.menu.getOfflineReason(), left, top,
                 GRID_SIZE * SLOT_SIZE, GRID_SIZE * SLOT_SIZE);
 
         int resultX = this.leftPos + RESULT_LEFT_OFFSET;

--- a/src/main/java/appeng/client/screen/PatternTerminalScreen.java
+++ b/src/main/java/appeng/client/screen/PatternTerminalScreen.java
@@ -6,6 +6,7 @@ import net.minecraft.client.gui.components.Button;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Inventory;
 
+import appeng.client.gui.OfflineOverlayRenderer;
 import appeng.core.network.AE2Packets;
 import appeng.menu.terminal.PatternTerminalMenu;
 
@@ -53,6 +54,14 @@ public class PatternTerminalScreen extends CraftingTerminalScreen {
     }
 
     @Override
+    public void render(GuiGraphics graphics, int mouseX, int mouseY, float partialTick) {
+        super.render(graphics, mouseX, mouseY, partialTick);
+        if (!this.menu.isGridOnline()) {
+            renderPatternOfflineOverlay(graphics);
+        }
+    }
+
+    @Override
     protected void renderBg(GuiGraphics graphics, float partialTicks, int mouseX, int mouseY) {
         super.renderBg(graphics, partialTicks, mouseX, mouseY);
 
@@ -62,6 +71,16 @@ public class PatternTerminalScreen extends CraftingTerminalScreen {
 
         int encodedLeft = this.leftPos + ENCODED_PATTERN_X;
         graphics.fill(encodedLeft, top, encodedLeft + 16, top + 16, 0xFF3F3F3F);
+    }
+
+    private void renderPatternOfflineOverlay(GuiGraphics graphics) {
+        int left = this.leftPos + BLANK_PATTERN_X;
+        int top = this.topPos + PATTERN_SLOT_Y;
+        OfflineOverlayRenderer.renderForReason(graphics, this.font, this.menu.getOfflineReason(), left, top, 16, 16);
+
+        int encodedLeft = this.leftPos + ENCODED_PATTERN_X;
+        OfflineOverlayRenderer.renderForReason(graphics, this.font, this.menu.getOfflineReason(), encodedLeft, top, 16,
+                16);
     }
 
     private void sendToggleRequest() {

--- a/src/main/java/appeng/client/screen/SimpleDriveScreen.java
+++ b/src/main/java/appeng/client/screen/SimpleDriveScreen.java
@@ -9,7 +9,6 @@ import net.minecraft.world.entity.player.Inventory;
 
 import appeng.api.config.RedstoneMode;
 import appeng.client.gui.OfflineOverlayRenderer;
-import appeng.grid.SimpleGridNode.OfflineReason;
 import appeng.menu.simple.SimpleDriveMenu;
 
 public class SimpleDriveScreen extends AbstractContainerScreen<SimpleDriveMenu> {
@@ -124,15 +123,6 @@ public class SimpleDriveScreen extends AbstractContainerScreen<SimpleDriveMenu> 
         int y = this.topPos + 20;
         int width = 18 * 2;
         int height = 18 * 2;
-        OfflineOverlayRenderer.renderWithMessage(graphics, this.font, getOfflineMessage(), x, y, width, height);
-    }
-
-    private Component getOfflineMessage() {
-        OfflineReason reason = this.menu.getOfflineReason();
-        return switch (reason) {
-            case REDSTONE -> Component.translatable("gui.appliedenergistics2.offline.redstone");
-            case CHANNELS -> Component.translatable("gui.appliedenergistics2.offline.channels");
-            default -> Component.translatable("gui.appliedenergistics2.offline.power");
-        };
+        OfflineOverlayRenderer.renderForReason(graphics, this.font, this.menu.getOfflineReason(), x, y, width, height);
     }
 }

--- a/src/main/java/appeng/client/screen/TerminalScreen.java
+++ b/src/main/java/appeng/client/screen/TerminalScreen.java
@@ -22,7 +22,6 @@ import appeng.api.storage.ItemStackView;
 import appeng.client.gui.OfflineOverlayRenderer;
 import appeng.core.network.serverbound.TerminalExtractPacket;
 import appeng.menu.terminal.TerminalMenu;
-import appeng.grid.SimpleGridNode.OfflineReason;
 
 public class TerminalScreen extends AbstractContainerScreen<TerminalMenu> {
     private static final int SLOT_SIZE = 18;
@@ -80,6 +79,7 @@ public class TerminalScreen extends AbstractContainerScreen<TerminalMenu> {
         super.init();
         this.searchBox = new EditBox(this.font, this.leftPos + 8, this.topPos + 6, 120, 12,
                 Component.translatable("gui.appliedenergistics2.terminal.search"));
+        this.searchBox.setHint(Component.translatable("gui.appliedenergistics2.terminal.search_hint"));
         this.searchBox.setResponder(value -> this.scrollIndex = 0);
         this.searchBox.setMaxLength(64);
         this.addRenderableWidget(this.searchBox);
@@ -298,7 +298,7 @@ public class TerminalScreen extends AbstractContainerScreen<TerminalMenu> {
         int y = getListTop();
         int width = getItemsPerRow() * getSlotSize();
         int height = getVisibleRows() * getSlotSize();
-        OfflineOverlayRenderer.renderWithMessage(graphics, this.font, getOfflineMessage(), x, y, width, height);
+        OfflineOverlayRenderer.renderForReason(graphics, this.font, this.menu.getOfflineReason(), x, y, width, height);
     }
 
     private void updateRedstoneButton() {
@@ -324,15 +324,6 @@ public class TerminalScreen extends AbstractContainerScreen<TerminalMenu> {
         }
         this.redstoneButton.setMessage(label);
         this.redstoneButton.setTooltip(Tooltip.create(tooltip));
-    }
-
-    private Component getOfflineMessage() {
-        OfflineReason reason = this.menu.getOfflineReason();
-        return switch (reason) {
-            case REDSTONE -> Component.translatable("gui.appliedenergistics2.offline.redstone");
-            case CHANNELS -> Component.translatable("gui.appliedenergistics2.offline.channels");
-            default -> Component.translatable("gui.appliedenergistics2.offline.power");
-        };
     }
 
     private String formatAmount(int count) {

--- a/src/main/java/appeng/datagen/AE2LanguageProvider.java
+++ b/src/main/java/appeng/datagen/AE2LanguageProvider.java
@@ -133,6 +133,7 @@ public class AE2LanguageProvider extends LanguageProvider {
         add("tooltip.ae2.cell.types", "Types: %s / %s");
         add("tooltip.ae2.cell.priority", "Priority: %s");
         add("gui.appliedenergistics2.terminal.search", "Search Items");
+        add("gui.appliedenergistics2.terminal.search_hint", "Type to filter stored items");
         add("gui.ae2.ClearWhitelist", "Clear Whitelist");
     }
 }


### PR DESCRIPTION
## Summary
- centralize offline overlay messaging in `OfflineOverlayRenderer`
- apply the overlay helper to crafting/pattern terminals and the simple drive screen
- add a localized hint string for terminal search boxes and wire it up in the UI

## Testing
- `./gradlew clean build --no-daemon --console=plain` *(fails: settings.gradle rejects plugins block prior statements)*

------
https://chatgpt.com/codex/tasks/task_e_68e3dc1f7e408327a2abdff6e9b7adb3