### PR TITLE
Phase 4 interop scaffolding and payload sync

### DIFF
--- a/docs/INTEGRATION_CHECKLIST.md
+++ b/docs/INTEGRATION_CHECKLIST.md
@@ -1,0 +1,6 @@
+# Integration Checklist (Phase 4)
+
+Track critical integration toggles while payload migration is underway.
+
+- [ ] Curios, JEI, REI, EMI interop hooks reachable
+- [ ] Payload sync tested for Crafting Jobs / Partitioned Cells / Storage Bus

--- a/docs/PORT_MATRIX.md
+++ b/docs/PORT_MATRIX.md
@@ -5,7 +5,8 @@ and the Phase 3 datagen checkpoints exercised during validation.
 
 | Stonecutter Target | NeoForge Build | Phase 3 Datagen Checkpoints |
 | ------------------ | -------------- | ---------------------------- |
-| Default (1.21.4)   | 21.4.154       | ✅ Storage cells, ✅ Crafting CPU, ✅ Pattern terminals, ✅ Processing registry, ✅ Lang diagnostics |
+| 1.21.1             | TBD            | ⚠️ Interop stubs and payload migration in progress |
+| Default (1.21.4)   | 21.4.154       | ⚠️ Interop stubs and payload migration in progress |
 | 1.21.5             | 21.5.95        | ✅ Storage cells, ✅ Pattern terminals, ✅ IO busses, ✅ Lang diagnostics |
 | 1.21.6             | 21.6.20-beta   | ✅ Upgrade cards, ✅ Processing registry, ✅ Lang diagnostics |
 | 1.21.7             | 21.7.25-beta   | 🔄 Pending validation |

--- a/src/main/java/appeng/api/compat/CuriosCompat.java
+++ b/src/main/java/appeng/api/compat/CuriosCompat.java
@@ -33,6 +33,15 @@ public final class CuriosCompat {
         return Optional.ofNullable(player.getCapability(CuriosIntegration.ITEM_HANDLER));
     }
 
+    public static boolean register() {
+        if (!isLoaded()) {
+            return false;
+        }
+
+        reportBridgeInitialized();
+        return true;
+    }
+
     public static Optional<IItemHandler> getCuriosHandler(@Nullable Player player, int slot) {
         if (player == null) {
             return Optional.empty();

--- a/src/main/java/appeng/api/compat/JeiCompat.java
+++ b/src/main/java/appeng/api/compat/JeiCompat.java
@@ -14,6 +14,15 @@ public final class JeiCompat {
         return ModList.get().isLoaded(MOD_ID);
     }
 
+    public static boolean register() {
+        if (!isLoaded()) {
+            return false;
+        }
+
+        reportBridgeInitialized();
+        return true;
+    }
+
     public static void reportBridgeInitialized() {
         if (isLoaded()) {
             AE2InteropValidator.markBridgeInitialized("JEI plugin bridge");

--- a/src/main/java/appeng/api/compat/ReiCompat.java
+++ b/src/main/java/appeng/api/compat/ReiCompat.java
@@ -14,6 +14,15 @@ public final class ReiCompat {
         return ModList.get().isLoaded(MOD_ID) || ModList.get().isLoaded("rei");
     }
 
+    public static boolean register() {
+        if (!isLoaded()) {
+            return false;
+        }
+
+        reportBridgeInitialized();
+        return true;
+    }
+
     public static void reportBridgeInitialized() {
         if (isLoaded()) {
             AE2InteropValidator.markBridgeInitialized("REI client bridge");

--- a/src/main/java/appeng/core/AppEngBase.java
+++ b/src/main/java/appeng/core/AppEngBase.java
@@ -79,6 +79,7 @@ import appeng.init.internal.InitStorageCells;
 import appeng.init.internal.InitUpgrades;
 import appeng.init.worldgen.InitStructures;
 import appeng.integration.Integrations;
+import appeng.integration.compat.InteropBootstrap;
 import appeng.registry.AE2Conditions;
 import appeng.registry.AE2RecipeSerializers;
 import appeng.registry.AE2RecipeTypes;
@@ -188,6 +189,8 @@ public abstract class AppEngBase implements AppEng {
         NeoForge.EVENT_BUS.addListener(SkyStoneBreakSpeed::handleBreakFaster);
 
         HotkeyActions.init();
+
+        InteropBootstrap.registerInterop();
     }
 
     private void commonSetup(FMLCommonSetupEvent event) {

--- a/src/main/java/appeng/core/network/AE2Network.java
+++ b/src/main/java/appeng/core/network/AE2Network.java
@@ -11,11 +11,14 @@ import appeng.core.network.payload.AE2ActionC2SPayload;
 import appeng.core.network.payload.AE2HelloS2CPayload;
 import appeng.core.network.payload.AE2LoginAckC2SPayload;
 import appeng.core.network.payload.AE2LoginSyncS2CPayload;
+import appeng.core.network.payload.CraftingJobSyncS2CPayload;
 import appeng.core.network.payload.EncodePatternC2SPayload;
+import appeng.core.network.payload.PartitionedCellSyncS2CPayload;
 import appeng.core.network.payload.PlanCraftingJobC2SPayload;
 import appeng.core.network.payload.PlannedCraftingJobS2CPayload;
 import appeng.core.network.payload.S2CJobUpdatePayload;
 import appeng.core.network.payload.SetPatternEncodingModeC2SPayload;
+import appeng.core.network.payload.StorageBusStateS2CPayload;
 
 @EventBusSubscriber(modid = AppEng.MOD_ID, bus = EventBusSubscriber.Bus.MOD)
 public final class AE2Network {
@@ -36,6 +39,12 @@ public final class AE2Network {
                 AE2NetworkHandlers::handlePlannedCraftingJobClient);
         play.playToClient(S2CJobUpdatePayload.TYPE, S2CJobUpdatePayload.STREAM_CODEC,
                 AE2NetworkHandlers::handleJobUpdateClient);
+        play.playToClient(CraftingJobSyncS2CPayload.TYPE, CraftingJobSyncS2CPayload.STREAM_CODEC,
+                AE2NetworkHandlers::handleCraftingJobSyncClient);
+        play.playToClient(PartitionedCellSyncS2CPayload.TYPE, PartitionedCellSyncS2CPayload.STREAM_CODEC,
+                AE2NetworkHandlers::handlePartitionedCellSyncClient);
+        play.playToClient(StorageBusStateS2CPayload.TYPE, StorageBusStateS2CPayload.STREAM_CODEC,
+                AE2NetworkHandlers::handleStorageBusStateClient);
 
         play.playToServer(AE2ActionC2SPayload.TYPE, AE2ActionC2SPayload.STREAM_CODEC,
                 AE2NetworkHandlers::handleActionServer);

--- a/src/main/java/appeng/core/network/AE2Packets.java
+++ b/src/main/java/appeng/core/network/AE2Packets.java
@@ -1,17 +1,29 @@
 package appeng.core.network;
 
+import java.util.List;
+
+import org.jetbrains.annotations.Nullable;
+
 import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.neoforged.neoforge.network.PacketDistributor;
 
+import appeng.api.config.AccessRestriction;
+import appeng.api.config.StorageFilter;
+import appeng.api.config.YesNo;
 import appeng.core.network.payload.AE2ActionC2SPayload;
 import appeng.core.network.payload.AE2HelloS2CPayload;
+import appeng.core.network.payload.CraftingJobSyncS2CPayload;
 import appeng.core.network.payload.EncodePatternC2SPayload;
+import appeng.core.network.payload.PartitionedCellSyncS2CPayload;
 import appeng.core.network.payload.PlanCraftingJobC2SPayload;
 import appeng.core.network.payload.PlannedCraftingJobS2CPayload;
 import appeng.core.network.payload.S2CJobUpdatePayload;
 import appeng.core.network.payload.SetPatternEncodingModeC2SPayload;
+import appeng.core.network.payload.StorageBusStateS2CPayload;
 
 import appeng.crafting.CraftingJob;
 
@@ -46,8 +58,32 @@ public final class AE2Packets {
 
     public static void sendCraftingJobUpdate(ServerLevel level, BlockPos pos, CraftingJob job) {
         PacketDistributor.sendToPlayersNear(level, null, pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5, 32,
-                new S2CJobUpdatePayload(job.getId(), job.getState(), job.isProcessing(), job.getTicksCompleted(),
-                        job.getTicksRequired(), job.getInsertedOutputs(), job.getDroppedOutputs(), job.getParentJobId(),
-                        job.getSubJobStatuses(), job.getOutputs()));
+                createCraftingJobUpdate(job));
+    }
+
+    public static S2CJobUpdatePayload createCraftingJobUpdate(CraftingJob job) {
+        return new S2CJobUpdatePayload(job.getId(), job.getState(), job.isProcessing(), job.getTicksCompleted(),
+                job.getTicksRequired(), job.getInsertedOutputs(), job.getDroppedOutputs(), job.getParentJobId(),
+                job.getSubJobStatuses(), job.getOutputs());
+    }
+
+    public static void sendCraftingJobSync(ServerPlayer player, List<S2CJobUpdatePayload> jobs) {
+        if (jobs.isEmpty()) {
+            return;
+        }
+
+        PacketDistributor.sendToPlayer(player, new CraftingJobSyncS2CPayload(jobs));
+    }
+
+    public static void sendPartitionedCellSync(ServerPlayer player, int containerId, int priority,
+            List<ResourceLocation> whitelist) {
+        PacketDistributor.sendToPlayer(player,
+                new PartitionedCellSyncS2CPayload(containerId, priority, whitelist));
+    }
+
+    public static void sendStorageBusState(ServerPlayer player, int containerId, AccessRestriction accessMode,
+            StorageFilter storageFilter, YesNo filterOnExtract, @Nullable Component connectedTo) {
+        PacketDistributor.sendToPlayer(player,
+                new StorageBusStateS2CPayload(containerId, accessMode, storageFilter, filterOnExtract, connectedTo));
     }
 }

--- a/src/main/java/appeng/core/network/payload/CraftingJobSyncS2CPayload.java
+++ b/src/main/java/appeng/core/network/payload/CraftingJobSyncS2CPayload.java
@@ -1,0 +1,43 @@
+package appeng.core.network.payload;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload.Type;
+
+import appeng.core.AppEng;
+
+public record CraftingJobSyncS2CPayload(List<S2CJobUpdatePayload> jobs) implements CustomPacketPayload {
+    public CraftingJobSyncS2CPayload {
+        jobs = List.copyOf(jobs);
+    }
+
+    public static final Type<CraftingJobSyncS2CPayload> TYPE = new Type<>(AppEng.makeId("crafting_job_sync"));
+
+    public static final StreamCodec<FriendlyByteBuf, CraftingJobSyncS2CPayload> STREAM_CODEC = StreamCodec.of(
+            CraftingJobSyncS2CPayload::write, CraftingJobSyncS2CPayload::read);
+
+    private static CraftingJobSyncS2CPayload read(FriendlyByteBuf buf) {
+        int size = buf.readVarInt();
+        List<S2CJobUpdatePayload> jobs = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            jobs.add(S2CJobUpdatePayload.STREAM_CODEC.decode(buf));
+        }
+        return new CraftingJobSyncS2CPayload(jobs);
+    }
+
+    private static void write(FriendlyByteBuf buf, CraftingJobSyncS2CPayload payload) {
+        buf.writeVarInt(payload.jobs().size());
+        for (var job : payload.jobs()) {
+            S2CJobUpdatePayload.STREAM_CODEC.encode(buf, job);
+        }
+    }
+
+    @Override
+    public Type<CraftingJobSyncS2CPayload> type() {
+        return TYPE;
+    }
+}

--- a/src/main/java/appeng/core/network/payload/PartitionedCellSyncS2CPayload.java
+++ b/src/main/java/appeng/core/network/payload/PartitionedCellSyncS2CPayload.java
@@ -1,0 +1,49 @@
+package appeng.core.network.payload;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload.Type;
+import net.minecraft.resources.ResourceLocation;
+
+import appeng.core.AppEng;
+
+public record PartitionedCellSyncS2CPayload(int containerId, int priority, List<ResourceLocation> whitelist)
+        implements CustomPacketPayload {
+    public PartitionedCellSyncS2CPayload {
+        whitelist = List.copyOf(whitelist);
+    }
+
+    public static final Type<PartitionedCellSyncS2CPayload> TYPE = new Type<>(AppEng.makeId("partitioned_cell_sync"));
+
+    public static final StreamCodec<FriendlyByteBuf, PartitionedCellSyncS2CPayload> STREAM_CODEC = StreamCodec.of(
+            PartitionedCellSyncS2CPayload::write, PartitionedCellSyncS2CPayload::read);
+
+    private static PartitionedCellSyncS2CPayload read(FriendlyByteBuf buf) {
+        int containerId = buf.readVarInt();
+        int priority = buf.readVarInt();
+        int size = buf.readVarInt();
+        List<ResourceLocation> whitelist = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            whitelist.add(buf.readResourceLocation());
+        }
+        return new PartitionedCellSyncS2CPayload(containerId, priority, whitelist);
+    }
+
+    private static void write(FriendlyByteBuf buf, PartitionedCellSyncS2CPayload payload) {
+        buf.writeVarInt(payload.containerId());
+        buf.writeVarInt(payload.priority());
+        buf.writeVarInt(payload.whitelist().size());
+        for (var id : payload.whitelist()) {
+            buf.writeResourceLocation(id);
+        }
+    }
+
+    @Override
+    public Type<PartitionedCellSyncS2CPayload> type() {
+        return TYPE;
+    }
+}

--- a/src/main/java/appeng/core/network/payload/StorageBusStateS2CPayload.java
+++ b/src/main/java/appeng/core/network/payload/StorageBusStateS2CPayload.java
@@ -1,0 +1,48 @@
+package appeng.core.network.payload;
+
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload.Type;
+
+import appeng.api.config.AccessRestriction;
+import appeng.api.config.StorageFilter;
+import appeng.api.config.YesNo;
+import appeng.core.AppEng;
+
+public record StorageBusStateS2CPayload(int containerId, AccessRestriction accessMode, StorageFilter storageFilter,
+        YesNo filterOnExtract, @Nullable Component connectedTo) implements CustomPacketPayload {
+
+    public static final Type<StorageBusStateS2CPayload> TYPE = new Type<>(AppEng.makeId("storage_bus_state"));
+
+    public static final StreamCodec<FriendlyByteBuf, StorageBusStateS2CPayload> STREAM_CODEC = StreamCodec.of(
+            StorageBusStateS2CPayload::write, StorageBusStateS2CPayload::read);
+
+    private static StorageBusStateS2CPayload read(FriendlyByteBuf buf) {
+        int containerId = buf.readVarInt();
+        AccessRestriction accessMode = buf.readEnum(AccessRestriction.class);
+        StorageFilter storageFilter = buf.readEnum(StorageFilter.class);
+        YesNo filterOnExtract = buf.readEnum(YesNo.class);
+        Component connectedTo = buf.readBoolean() ? buf.readComponent() : null;
+        return new StorageBusStateS2CPayload(containerId, accessMode, storageFilter, filterOnExtract, connectedTo);
+    }
+
+    private static void write(FriendlyByteBuf buf, StorageBusStateS2CPayload payload) {
+        buf.writeVarInt(payload.containerId());
+        buf.writeEnum(payload.accessMode());
+        buf.writeEnum(payload.storageFilter());
+        buf.writeEnum(payload.filterOnExtract());
+        buf.writeBoolean(payload.connectedTo() != null);
+        if (payload.connectedTo() != null) {
+            buf.writeComponent(payload.connectedTo());
+        }
+    }
+
+    @Override
+    public Type<StorageBusStateS2CPayload> type() {
+        return TYPE;
+    }
+}

--- a/src/main/java/appeng/crafting/CraftingJobManager.java
+++ b/src/main/java/appeng/crafting/CraftingJobManager.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Item;
 
@@ -27,6 +28,8 @@ import appeng.blockentity.crafting.CraftingCPUBlockEntity;
 import appeng.api.integration.machines.IProcessingMachine;
 import appeng.api.storage.ItemStackView;
 import appeng.blockentity.crafting.MolecularAssemblerBlockEntity;
+import appeng.core.network.AE2Packets;
+import appeng.core.network.payload.S2CJobUpdatePayload;
 import appeng.integration.processing.ProcessingMachineExecutor;
 import appeng.integration.processing.ProcessingMachineRegistry;
 
@@ -485,6 +488,21 @@ public final class CraftingJobManager {
         markJobFailed(job, reason);
         if (cpu != null) {
             cpu.releaseReservation(job.getId());
+        }
+    }
+
+    public void syncJobs(ServerPlayer player) {
+        if (player == null) {
+            return;
+        }
+
+        List<S2CJobUpdatePayload> updates = new ArrayList<>();
+        for (var job : jobs.values()) {
+            updates.add(AE2Packets.createCraftingJobUpdate(job));
+        }
+
+        if (!updates.isEmpty()) {
+            AE2Packets.sendCraftingJobSync(player, updates);
         }
     }
 

--- a/src/main/java/appeng/datagen/AELangProvider.java
+++ b/src/main/java/appeng/datagen/AELangProvider.java
@@ -125,6 +125,9 @@ public class AELangProvider extends LanguageProvider {
         add("message.appliedenergistics2.crafting_job.dependency_failed",
                 "Crafting job %s failed due to missing dependency.");
         add("message.appliedenergistics2.crafting_job.unknown_output", "Unknown output");
+        add("log.appliedenergistics2.interop.success", "Interop ready: %s");
+        add("log.appliedenergistics2.interop.skipped", "Interop skipped (mod missing): %s");
+        add("log.appliedenergistics2.interop.failed", "Interop failed: %s (%s)");
         add("gui.appliedenergistics2.pattern_encoding.mode.crafting", "Crafting Pattern");
         add("gui.appliedenergistics2.pattern_encoding.mode.processing", "Processing Pattern");
         add("gui.appliedenergistics2.pattern_encoding.mode_toggle_hint", "Click to switch pattern type.");

--- a/src/main/java/appeng/integration/modules/emi/AppEngEmiPlugin.java
+++ b/src/main/java/appeng/integration/modules/emi/AppEngEmiPlugin.java
@@ -29,6 +29,7 @@ import appeng.api.features.P2PTunnelAttunementInternal;
 import appeng.api.integrations.emi.EmiStackConverters;
 import appeng.api.upgrades.Upgrades;
 import appeng.core.AEConfig;
+import appeng.core.AE2InteropValidator;
 import appeng.core.AppEng;
 import appeng.core.FacadeCreativeTab;
 import appeng.core.definitions.AEBlocks;
@@ -46,9 +47,21 @@ import appeng.menu.me.items.WirelessCraftingTermMenu;
 import appeng.registry.AE2RecipeTypes;
 import appeng.recipes.game.StorageCellUpgradeRecipe;
 
+import net.neoforged.fml.ModList;
+
 @EmiEntrypoint
 public class AppEngEmiPlugin implements EmiPlugin {
+    public static final String MOD_ID = "emi";
     static final ResourceLocation TEXTURE = AppEng.makeId("textures/guis/jei.png");
+
+    public static boolean register() {
+        if (!ModList.get().isLoaded(MOD_ID)) {
+            return false;
+        }
+
+        AE2InteropValidator.markBridgeInitialized("EMI plugin bridge");
+        return true;
+    }
 
     @Override
     public void register(EmiRegistry registry) {

--- a/src/main/java/appeng/interop/AE2Interop.java
+++ b/src/main/java/appeng/interop/AE2Interop.java
@@ -1,12 +1,18 @@
 package appeng.interop;
 
+import java.util.function.Supplier;
+
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.world.level.block.entity.BlockEntity;
 
 import appeng.AE2Capabilities;
+import appeng.api.compat.CuriosCompat;
+import appeng.api.compat.JeiCompat;
+import appeng.api.compat.ReiCompat;
 import appeng.api.grid.IGridNode;
 import appeng.api.storage.IStorageService;
+import appeng.integration.modules.emi.AppEngEmiPlugin;
 
 /**
  * Simple helpers for third-party integrations to query AE2 grid node capabilities.
@@ -31,5 +37,47 @@ public final class AE2Interop {
     @Nullable
     public static IStorageService getStorage(BlockEntity be) {
         return be.getCapability(AE2Capabilities.STORAGE_SERVICE, null);
+    }
+
+    public static InteropRegistrationResult registerCuriosCompat() {
+        return attemptRegistration(CuriosCompat::register);
+    }
+
+    public static InteropRegistrationResult registerJeiCompat() {
+        return attemptRegistration(JeiCompat::register);
+    }
+
+    public static InteropRegistrationResult registerReiCompat() {
+        return attemptRegistration(ReiCompat::register);
+    }
+
+    public static InteropRegistrationResult registerEmiCompat() {
+        return attemptRegistration(AppEngEmiPlugin::register);
+    }
+
+    private static InteropRegistrationResult attemptRegistration(Supplier<Boolean> registration) {
+        try {
+            boolean loaded = registration.get();
+            if (loaded) {
+                return InteropRegistrationResult.success();
+            }
+            return InteropRegistrationResult.skipped();
+        } catch (Throwable t) {
+            return InteropRegistrationResult.failure(t);
+        }
+    }
+
+    public record InteropRegistrationResult(boolean success, boolean skipped, @Nullable Throwable error) {
+        public static InteropRegistrationResult success() {
+            return new InteropRegistrationResult(true, false, null);
+        }
+
+        public static InteropRegistrationResult skipped() {
+            return new InteropRegistrationResult(false, true, null);
+        }
+
+        public static InteropRegistrationResult failure(Throwable error) {
+            return new InteropRegistrationResult(false, false, error);
+        }
     }
 }

--- a/src/main/java/appeng/items/contents/PartitionedCellMenuHost.java
+++ b/src/main/java/appeng/items/contents/PartitionedCellMenuHost.java
@@ -180,7 +180,7 @@ public class PartitionedCellMenuHost extends ItemMenuHost<PartitionedCellItem> {
         }
     }
 
-    private List<ResourceLocation> getWhitelistEntries() {
+    public List<ResourceLocation> getWhitelistEntries() {
         List<ResourceLocation> whitelist = new ArrayList<>();
         for (int i = 0; i < whitelistInventory.size(); i++) {
             AEKey key = whitelistInventory.getKey(i);


### PR DESCRIPTION
## Summary
- add InteropBootstrap wiring so Curios, JEI, REI, and EMI registration stubs run during AppEng initialization with translated logging
- introduce crafting job, partitioned cell, and storage bus payloads and hook them into AE2Packets/AE2NetworkHandlers alongside menu updates
- extend CraftingJobManager sync, update docs, and seed language entries for the new interop scaffolding

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e40f2fec40832793716fcfd21f1b1a