### PR TITLE
Add filter and fluid monitoring to level emitter

### DIFF
--- a/src/main/java/appeng/blockentity/misc/LevelEmitterBlockEntity.java
+++ b/src/main/java/appeng/blockentity/misc/LevelEmitterBlockEntity.java
@@ -1,38 +1,51 @@
 package appeng.blockentity.misc;
 
+import org.jetbrains.annotations.Nullable;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 
+import appeng.api.behaviors.ContainerItemStrategies;
 import appeng.api.config.LevelEmitterMode;
 import appeng.api.config.Setting;
 import appeng.api.config.Settings;
+import appeng.api.inventories.InternalInventory;
+import appeng.api.inventories.ISegmentedInventory;
 import appeng.api.networking.IStackWatcher;
 import appeng.api.networking.storage.IStorageWatcherNode;
+import appeng.api.stacks.AEItemKey;
 import appeng.api.stacks.AEKey;
+import appeng.api.stacks.AEKeyType;
+import appeng.api.stacks.GenericStack;
 import appeng.api.util.IConfigManager;
 import appeng.api.util.IConfigurableObject;
 import appeng.block.misc.LevelEmitterBlock;
 import appeng.blockentity.grid.AENetworkedBlockEntity;
 import appeng.core.definitions.AEBlocks;
 import appeng.util.Platform;
+import appeng.util.inv.AppEngInternalInventory;
+import appeng.util.inv.InternalInventoryHost;
 
-public class LevelEmitterBlockEntity extends AENetworkedBlockEntity implements IConfigurableObject {
+public class LevelEmitterBlockEntity extends AENetworkedBlockEntity
+        implements IConfigurableObject, InternalInventoryHost {
 
     private final IConfigManager configManager = IConfigManager.builder(this::onSettingChanged)
             .registerSetting(Settings.LEVEL_EMITTER_MODE, LevelEmitterMode.GREATER_OR_EQUAL)
             .build();
 
+    private final AppEngInternalInventory filterInventory = new AppEngInternalInventory(this, 1, 1);
+
     private final IStorageWatcherNode storageWatcherNode = new IStorageWatcherNode() {
         @Override
         public void updateWatcher(IStackWatcher newWatcher) {
             storageWatcher = newWatcher;
-            if (storageWatcher != null) {
-                storageWatcher.setWatchAll(true);
-            }
+            configureStorageWatcher();
             updateStoredAmount();
         }
 
@@ -68,6 +81,7 @@ public class LevelEmitterBlockEntity extends AENetworkedBlockEntity implements I
         this.cachedAmount = data.getLong("cachedAmount");
         this.emitting = data.getBoolean("emitting");
         configManager.readFromNBT(data, registries);
+        filterInventory.readFromNBT(data, "filter", registries);
     }
 
     @Override
@@ -77,6 +91,7 @@ public class LevelEmitterBlockEntity extends AENetworkedBlockEntity implements I
         data.putLong("cachedAmount", cachedAmount);
         data.putBoolean("emitting", emitting);
         configManager.writeToNBT(data, registries);
+        filterInventory.writeToNBT(data, "filter", registries);
     }
 
     public void setThreshold(long newThreshold) {
@@ -105,6 +120,59 @@ public class LevelEmitterBlockEntity extends AENetworkedBlockEntity implements I
         evaluateEmission();
     }
 
+    private void configureStorageWatcher() {
+        if (this.storageWatcher == null) {
+            return;
+        }
+
+        this.storageWatcher.reset();
+
+        var filter = getFilterKey();
+        if (filter == null) {
+            this.storageWatcher.setWatchAll(true);
+        } else {
+            this.storageWatcher.add(filter);
+        }
+    }
+
+    private void onFilterChanged() {
+        if (isClientSide()) {
+            return;
+        }
+
+        configureStorageWatcher();
+        updateStoredAmount();
+        saveChanges();
+    }
+
+    @Nullable
+    public AEKey getFilterKey() {
+        return getFilterKey(filterInventory.getStackInSlot(0));
+    }
+
+    @Nullable
+    public static AEKey getFilterKey(ItemStack stack) {
+        if (stack.isEmpty()) {
+            return null;
+        }
+
+        var wrapped = GenericStack.unwrapItemStack(stack);
+        if (wrapped != null) {
+            return wrapped.what();
+        }
+
+        var containedFluid = ContainerItemStrategies.getContainedStack(stack, AEKeyType.fluids());
+        if (containedFluid != null) {
+            return containedFluid.what();
+        }
+
+        return AEItemKey.of(stack);
+    }
+
+    public InternalInventory getConfigInventory() {
+        return filterInventory;
+    }
+
     private void updateStoredAmount() {
         if (level == null || level.isClientSide()) {
             return;
@@ -117,11 +185,18 @@ public class LevelEmitterBlockEntity extends AENetworkedBlockEntity implements I
         var grid = getMainNode().getGrid();
         long total = 0;
         if (grid != null) {
-            for (var stack : grid.getStorageService().getCachedInventory()) {
-                total += stack.getLongValue();
-                if (total < 0) {
-                    total = Long.MAX_VALUE;
-                    break;
+            var filter = getFilterKey();
+            if (filter != null) {
+                total = grid.getStorageService().getCachedInventory().get(filter);
+            } else {
+                for (var entry : grid.getStorageService().getCachedInventory()) {
+                    if (entry.getKey() instanceof AEItemKey) {
+                        total += entry.getLongValue();
+                        if (total < 0) {
+                            total = Long.MAX_VALUE;
+                            break;
+                        }
+                    }
                 }
             }
         }
@@ -173,5 +248,33 @@ public class LevelEmitterBlockEntity extends AENetworkedBlockEntity implements I
     @Override
     public IConfigManager getConfigManager() {
         return configManager;
+    }
+
+    @Override
+    public void saveChangedInventory(AppEngInternalInventory inv) {
+        if (inv == filterInventory) {
+            saveChanges();
+        }
+    }
+
+    @Override
+    public void onChangeInventory(AppEngInternalInventory inv, int slot) {
+        if (inv == filterInventory) {
+            onFilterChanged();
+        }
+    }
+
+    @Override
+    public boolean isClientSide() {
+        return super.isClientSide();
+    }
+
+    @Override
+    public InternalInventory getSubInventory(ResourceLocation id) {
+        if (ISegmentedInventory.CONFIG.equals(id)) {
+            return filterInventory;
+        }
+
+        return super.getSubInventory(id);
     }
 }

--- a/src/main/java/appeng/client/gui/implementations/LevelEmitterScreen.java
+++ b/src/main/java/appeng/client/gui/implementations/LevelEmitterScreen.java
@@ -1,21 +1,31 @@
 package appeng.client.gui.implementations;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
 
 import appeng.api.config.LevelEmitterMode;
 import appeng.api.config.Settings;
+import appeng.api.stacks.AEFluidKey;
+import appeng.api.stacks.AEKey;
 import appeng.client.gui.AEBaseScreen;
 import appeng.client.gui.NumberEntryType;
 import appeng.client.gui.style.ScreenStyle;
 import appeng.client.gui.widgets.NumberEntryWidget;
 import appeng.client.gui.widgets.ServerSettingToggleButton;
+import appeng.core.localization.GuiText;
+import appeng.menu.SlotSemantics;
 import appeng.menu.implementations.LevelEmitterMenu;
 
 public class LevelEmitterScreen extends AEBaseScreen<LevelEmitterMenu> {
 
     private final ServerSettingToggleButton<LevelEmitterMode> modeButton;
     private final NumberEntryWidget thresholdEntry;
+    private final Slot filterSlot;
 
     public LevelEmitterScreen(LevelEmitterMenu menu, Inventory playerInventory, Component title, ScreenStyle style) {
         super(menu, playerInventory, title, style);
@@ -23,11 +33,14 @@ public class LevelEmitterScreen extends AEBaseScreen<LevelEmitterMenu> {
         this.modeButton = new ServerSettingToggleButton<>(Settings.LEVEL_EMITTER_MODE, menu.getMode());
         this.addToLeftToolbar(this.modeButton);
 
-        this.thresholdEntry = widgets.addNumberEntryWidget("level", NumberEntryType.UNITLESS);
+        this.thresholdEntry = widgets.addNumberEntryWidget("level", NumberEntryType.of(menu.getMonitoredKey()));
         this.thresholdEntry.setTextFieldStyle(style.getWidget("levelInput"));
         this.thresholdEntry.setLongValue(menu.getThreshold());
         this.thresholdEntry.setOnChange(this::saveThreshold);
         this.thresholdEntry.setOnConfirm(this::onClose);
+
+        var configSlots = menu.getSlots(SlotSemantics.CONFIG);
+        this.filterSlot = configSlots.isEmpty() ? null : configSlots.get(0);
     }
 
     @Override
@@ -35,6 +48,7 @@ public class LevelEmitterScreen extends AEBaseScreen<LevelEmitterMenu> {
         super.updateBeforeRender();
 
         this.modeButton.set(menu.getMode());
+        this.thresholdEntry.setType(NumberEntryType.of(menu.getMonitoredKey()));
         if (!this.thresholdEntry.isFocused()) {
             this.thresholdEntry.setLongValue(menu.getThreshold());
         }
@@ -42,5 +56,52 @@ public class LevelEmitterScreen extends AEBaseScreen<LevelEmitterMenu> {
 
     private void saveThreshold() {
         this.thresholdEntry.getLongValue().ifPresent(menu::setThreshold);
+    }
+
+    @Override
+    public void render(net.minecraft.client.gui.GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
+        super.render(guiGraphics, mouseX, mouseY, partialTick);
+
+        if (filterSlot != null && hoveredSlot == filterSlot && !filterSlot.hasItem()) {
+            var tooltip = getMonitoringTooltip();
+            if (!tooltip.isEmpty()) {
+                drawTooltip(guiGraphics, mouseX, mouseY, tooltip);
+            }
+        }
+    }
+
+    @Override
+    protected List<Component> getTooltipFromContainerItem(ItemStack stack) {
+        var tooltip = new ArrayList<>(super.getTooltipFromContainerItem(stack));
+
+        if (hoveredSlot == filterSlot) {
+            var monitoringTooltip = getMonitoringTooltip();
+            if (!monitoringTooltip.isEmpty()) {
+                if (!tooltip.isEmpty()) {
+                    tooltip.add(Component.literal(""));
+                }
+                tooltip.addAll(monitoringTooltip);
+            }
+        }
+
+        return tooltip;
+    }
+
+    private List<Component> getMonitoringTooltip() {
+        var tooltip = new ArrayList<Component>(2);
+        AEKey monitoredKey = menu.getMonitoredKey();
+        boolean monitoringFluids = monitoredKey instanceof AEFluidKey;
+
+        tooltip.add(Component.translatable(
+                monitoringFluids ? "gui.ae2.level_emitter.mode.fluids" : "gui.ae2.level_emitter.mode.items"));
+
+        Component value = monitoredKey != null ? monitoredKey.getDisplayName().copy()
+                : (monitoringFluids ? GuiText.Fluids.text() : GuiText.Items.text());
+
+        tooltip.add(Component.translatable("gui.ae2.level_emitter.filter")
+                .append(Component.literal(": "))
+                .append(value));
+
+        return tooltip;
     }
 }

--- a/src/main/java/appeng/datagen/providers/localization/LocalizationProvider.java
+++ b/src/main/java/appeng/datagen/providers/localization/LocalizationProvider.java
@@ -165,6 +165,9 @@ public class LocalizationProvider implements IAE2DataProvider {
         add("gui.ae2.upgrades.redstone", "Redstone cards allow the bus to respect redstone signal settings.");
         add("gui.ae2.upgrades.fuzzy", "Fuzzy cards enable partial and variant item matching.");
         add("gui.ae2.upgrades.inverter", "Inverter cards swap whitelist and blacklist filtering.");
+        add("gui.ae2.level_emitter.filter", "Filter");
+        add("gui.ae2.level_emitter.mode.items", "Items");
+        add("gui.ae2.level_emitter.mode.fluids", "Fluids");
     }
 
     private CompletableFuture<?> save(CachedOutput cache, Map<String, String> localizations) {

--- a/src/main/java/appeng/menu/implementations/LevelEmitterMenu.java
+++ b/src/main/java/appeng/menu/implementations/LevelEmitterMenu.java
@@ -1,13 +1,20 @@
 package appeng.menu.implementations;
 
+import org.jetbrains.annotations.Nullable;
+
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.MenuType;
+import net.minecraft.world.inventory.Slot;
 
 import appeng.api.config.LevelEmitterMode;
+import appeng.api.inventories.InternalInventory;
+import appeng.api.stacks.AEKey;
 import appeng.blockentity.misc.LevelEmitterBlockEntity;
 import appeng.menu.AEBaseMenu;
+import appeng.menu.SlotSemantics;
 import appeng.menu.implementations.MenuTypeBuilder;
 import appeng.menu.guisync.GuiSync;
+import appeng.menu.slot.FakeSlot;
 
 public class LevelEmitterMenu extends AEBaseMenu {
 
@@ -35,6 +42,16 @@ public class LevelEmitterMenu extends AEBaseMenu {
         super(menuType, id, inventory, host);
 
         registerClientAction(ACTION_SET_THRESHOLD, Long.class, this::handleSetThreshold);
+
+        InternalInventory configInventory = null;
+        if (host != null) {
+            configInventory = host.getConfigInventory();
+        } else if (getBlockEntity() instanceof LevelEmitterBlockEntity be) {
+            configInventory = be.getConfigInventory();
+        }
+        if (configInventory != null) {
+            this.addSlot(new FakeSlot(configInventory, 0), SlotSemantics.CONFIG);
+        }
         createPlayerInventorySlots(inventory);
     }
 
@@ -71,5 +88,20 @@ public class LevelEmitterMenu extends AEBaseMenu {
         if (value != null && getBlockEntity() instanceof LevelEmitterBlockEntity levelEmitter) {
             levelEmitter.setThreshold(value);
         }
+    }
+
+    @Nullable
+    public AEKey getMonitoredKey() {
+        if (getBlockEntity() instanceof LevelEmitterBlockEntity levelEmitter) {
+            return levelEmitter.getFilterKey();
+        }
+
+        var slots = getSlots(SlotSemantics.CONFIG);
+        if (!slots.isEmpty()) {
+            Slot slot = slots.get(0);
+            return LevelEmitterBlockEntity.getFilterKey(slot.getItem());
+        }
+
+        return null;
     }
 }

--- a/src/main/resources/assets/ae2/screens/level_emitter.json
+++ b/src/main/resources/assets/ae2/screens/level_emitter.json
@@ -24,6 +24,15 @@
         "left": 8,
         "top": 6
       }
+    },
+    "filter_label": {
+      "text": {
+        "translate": "gui.ae2.level_emitter.filter"
+      },
+      "position": {
+        "left": 134,
+        "top": 28
+      }
     }
   },
   "widgets": {

--- a/src/main/resources/assets/ae2/screens/level_emitter_block.json
+++ b/src/main/resources/assets/ae2/screens/level_emitter_block.json
@@ -9,6 +9,12 @@
     "texture": "guis/level_emitter.png",
     "srcRect": [0, 0, 176, 186]
   },
+  "slots": {
+    "CONFIG": {
+      "left": 137,
+      "top": 40
+    }
+  },
   "text": {
     "dialog_title": {
       "text": {
@@ -17,6 +23,15 @@
       "position": {
         "left": 8,
         "top": 6
+      }
+    },
+    "filter_label": {
+      "text": {
+        "translate": "gui.ae2.level_emitter.filter"
+      },
+      "position": {
+        "left": 134,
+        "top": 28
       }
     }
   },


### PR DESCRIPTION
## Summary
- add a dedicated filter inventory to the level emitter block entity, configure storage watchers, and interpret fluid containers as AE keys
- expose the filter slot in the level emitter menu/screen with dynamic number entry units and monitoring tooltip
- add localization entries plus GUI labels for the new filter slot

## Testing
- `./gradlew check` *(fails: Execution failed for task ':1.21.4:neoFormApplyOfficialMappings'.)*

------
https://chatgpt.com/codex/tasks/task_e_68e46cef60ec8327b180c487b7b569e7