### PR TITLE
Add spatial IO port scaffolding

### DIFF
--- a/src/main/java/appeng/client/AE2ClientSetup.java
+++ b/src/main/java/appeng/client/AE2ClientSetup.java
@@ -13,10 +13,12 @@ import appeng.client.screen.CraftingTerminalScreen;
 import appeng.client.screen.InscriberScreen;
 import appeng.client.screen.PatternTerminalScreen;
 import appeng.client.screen.SimpleDriveScreen;
+import appeng.client.screen.spatial.SpatialIOPortScreen;
 import appeng.client.screen.TerminalScreen;
 import appeng.registry.AE2Menus;
 import appeng.menu.terminal.TerminalMenu;
 import appeng.menu.simple.SimpleDriveMenu;
+import appeng.menu.spatial.SpatialIOPortMenu;
 
 @EventBusSubscriber(modid = AE2Registries.MODID, bus = EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
 public final class AE2ClientSetup {
@@ -32,6 +34,7 @@ public final class AE2ClientSetup {
             MenuScreens.register(AE2Menus.CRAFTING_MONITOR_MENU.get(), CraftingMonitorScreen::new);
             MenuScreens.register(TerminalMenu.TYPE, TerminalScreen::new);
             MenuScreens.register(SimpleDriveMenu.TYPE, SimpleDriveScreen::new);
+            MenuScreens.register(SpatialIOPortMenu.TYPE, SpatialIOPortScreen::new);
         });
     }
 }

--- a/src/main/java/appeng/client/screen/spatial/SpatialIOPortScreen.java
+++ b/src/main/java/appeng/client/screen/spatial/SpatialIOPortScreen.java
@@ -1,0 +1,38 @@
+package appeng.client.screen.spatial;
+
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Inventory;
+
+import appeng.core.network.AE2Packets;
+import appeng.menu.spatial.SpatialIOPortMenu;
+
+public class SpatialIOPortScreen extends AbstractContainerScreen<SpatialIOPortMenu> {
+    public SpatialIOPortScreen(SpatialIOPortMenu menu, Inventory inventory, Component title) {
+        super(menu, inventory, title);
+        this.imageWidth = 176;
+        this.imageHeight = 166;
+    }
+
+    @Override
+    protected void init() {
+        super.init();
+        int left = this.leftPos;
+        int top = this.topPos;
+
+        addRenderableWidget(Button.builder(Component.translatable("gui.ae2.spatial.capture"), button -> {
+            AE2Packets.sendSpatialCapture(menu.containerId, menu.getBlockPos());
+        }).bounds(left + 10, top + 20, 80, 20).build());
+
+        addRenderableWidget(Button.builder(Component.translatable("gui.ae2.spatial.restore"), button -> {
+            AE2Packets.sendSpatialRestore(menu.containerId, menu.getBlockPos());
+        }).bounds(left + 10, top + 50, 80, 20).build());
+    }
+
+    @Override
+    protected void renderBg(GuiGraphics graphics, float partialTicks, int mouseX, int mouseY) {
+        // TODO: Draw spatial IO port background once textures are available.
+    }
+}

--- a/src/main/java/appeng/core/network/AE2Network.java
+++ b/src/main/java/appeng/core/network/AE2Network.java
@@ -19,6 +19,8 @@ import appeng.core.network.payload.PlannedCraftingJobS2CPayload;
 import appeng.core.network.payload.S2CJobUpdatePayload;
 import appeng.core.network.payload.SetPatternEncodingModeC2SPayload;
 import appeng.core.network.payload.StorageBusStateS2CPayload;
+import appeng.core.network.payload.SpatialCaptureC2SPayload;
+import appeng.core.network.payload.SpatialRestoreC2SPayload;
 
 @EventBusSubscriber(modid = AppEng.MOD_ID, bus = EventBusSubscriber.Bus.MOD)
 public final class AE2Network {
@@ -54,6 +56,10 @@ public final class AE2Network {
                 AE2NetworkHandlers::handleEncodePatternServer);
         play.playToServer(SetPatternEncodingModeC2SPayload.TYPE, SetPatternEncodingModeC2SPayload.STREAM_CODEC,
                 AE2NetworkHandlers::handleSetPatternEncodingModeServer);
+        play.playToServer(SpatialCaptureC2SPayload.TYPE, SpatialCaptureC2SPayload.STREAM_CODEC,
+                AE2NetworkHandlers::handleSpatialCaptureServer);
+        play.playToServer(SpatialRestoreC2SPayload.TYPE, SpatialRestoreC2SPayload.STREAM_CODEC,
+                AE2NetworkHandlers::handleSpatialRestoreServer);
 
         // Login (handshake) payloads
         final LoginPayloadRegistrar login = event.login();

--- a/src/main/java/appeng/core/network/AE2NetworkHandlers.java
+++ b/src/main/java/appeng/core/network/AE2NetworkHandlers.java
@@ -24,6 +24,8 @@ import appeng.core.network.payload.PlanCraftingJobC2SPayload;
 import appeng.core.network.payload.PlannedCraftingJobS2CPayload;
 import appeng.core.network.payload.S2CJobUpdatePayload;
 import appeng.core.network.payload.SetPatternEncodingModeC2SPayload;
+import appeng.core.network.payload.SpatialCaptureC2SPayload;
+import appeng.core.network.payload.SpatialRestoreC2SPayload;
 import appeng.core.network.payload.StorageBusStateS2CPayload;
 import appeng.crafting.CraftingJob;
 import appeng.crafting.CraftingJobManager;
@@ -33,6 +35,7 @@ import appeng.menu.SlotSemantics;
 import appeng.menu.implementations.PatternEncodingTerminalMenu;
 import appeng.menu.implementations.StorageBusMenu;
 import appeng.menu.terminal.PatternTerminalMenu;
+import appeng.menu.spatial.SpatialIOPortMenu;
 
 public final class AE2NetworkHandlers {
     private AE2NetworkHandlers() {
@@ -143,6 +146,54 @@ public final class AE2NetworkHandlers {
             }
 
             menu.setProcessingModeServer(payload.processing());
+        });
+        ctx.setPacketHandled(true);
+    }
+
+    public static void handleSpatialCaptureServer(final SpatialCaptureC2SPayload payload,
+            final IPayloadContext ctx) {
+        ctx.enqueueWork(() -> {
+            if (!(ctx.player() instanceof ServerPlayer player)) {
+                return;
+            }
+            if (!(player.containerMenu instanceof SpatialIOPortMenu menu)) {
+                return;
+            }
+            if (menu.containerId != payload.containerId()) {
+                return;
+            }
+            if (!menu.getBlockPos().equals(payload.pos())) {
+                return;
+            }
+
+            var port = menu.getBlockEntity();
+            if (port != null && !port.isRemoved()) {
+                port.captureRegion();
+            }
+        });
+        ctx.setPacketHandled(true);
+    }
+
+    public static void handleSpatialRestoreServer(final SpatialRestoreC2SPayload payload,
+            final IPayloadContext ctx) {
+        ctx.enqueueWork(() -> {
+            if (!(ctx.player() instanceof ServerPlayer player)) {
+                return;
+            }
+            if (!(player.containerMenu instanceof SpatialIOPortMenu menu)) {
+                return;
+            }
+            if (menu.containerId != payload.containerId()) {
+                return;
+            }
+            if (!menu.getBlockPos().equals(payload.pos())) {
+                return;
+            }
+
+            var port = menu.getBlockEntity();
+            if (port != null && !port.isRemoved()) {
+                port.restoreRegion();
+            }
         });
         ctx.setPacketHandled(true);
     }

--- a/src/main/java/appeng/core/network/AE2Packets.java
+++ b/src/main/java/appeng/core/network/AE2Packets.java
@@ -23,6 +23,8 @@ import appeng.core.network.payload.PlanCraftingJobC2SPayload;
 import appeng.core.network.payload.PlannedCraftingJobS2CPayload;
 import appeng.core.network.payload.S2CJobUpdatePayload;
 import appeng.core.network.payload.SetPatternEncodingModeC2SPayload;
+import appeng.core.network.payload.SpatialCaptureC2SPayload;
+import appeng.core.network.payload.SpatialRestoreC2SPayload;
 import appeng.core.network.payload.StorageBusStateS2CPayload;
 
 import appeng.crafting.CraftingJob;
@@ -85,5 +87,13 @@ public final class AE2Packets {
             StorageFilter storageFilter, YesNo filterOnExtract, @Nullable Component connectedTo) {
         PacketDistributor.sendToPlayer(player,
                 new StorageBusStateS2CPayload(containerId, accessMode, storageFilter, filterOnExtract, connectedTo));
+    }
+
+    public static void sendSpatialCapture(int containerId, BlockPos pos) {
+        PacketDistributor.sendToServer(new SpatialCaptureC2SPayload(containerId, pos));
+    }
+
+    public static void sendSpatialRestore(int containerId, BlockPos pos) {
+        PacketDistributor.sendToServer(new SpatialRestoreC2SPayload(containerId, pos));
     }
 }

--- a/src/main/java/appeng/core/network/InitNetwork.java
+++ b/src/main/java/appeng/core/network/InitNetwork.java
@@ -47,6 +47,8 @@ import appeng.core.network.serverbound.UpdateHoldingCtrlPacket;
 import appeng.core.network.serverbound.UpdatePartitionedCellPriorityPacket;
 import appeng.core.network.serverbound.UpdatePartitionedCellWhitelistModePacket;
 import appeng.core.network.serverbound.UpdatePartitionedCellWhitelistPacket;
+import appeng.core.network.payload.SpatialCaptureC2SPayload;
+import appeng.core.network.payload.SpatialRestoreC2SPayload;
 
 public class InitNetwork {
     public static void init(RegisterPayloadHandlersEvent event) {
@@ -97,6 +99,8 @@ public class InitNetwork {
                 UpdatePartitionedCellWhitelistModePacket.STREAM_CODEC);
         serverbound(registrar, UpdatePartitionedCellWhitelistPacket.TYPE,
                 UpdatePartitionedCellWhitelistPacket.STREAM_CODEC);
+        serverbound(registrar, SpatialCaptureC2SPayload.TYPE, SpatialCaptureC2SPayload.STREAM_CODEC);
+        serverbound(registrar, SpatialRestoreC2SPayload.TYPE, SpatialRestoreC2SPayload.STREAM_CODEC);
 
         // Bidirectional
         bidirectional(registrar, ConfigValuePacket.TYPE, ConfigValuePacket.STREAM_CODEC);

--- a/src/main/java/appeng/core/network/payload/SpatialCaptureC2SPayload.java
+++ b/src/main/java/appeng/core/network/payload/SpatialCaptureC2SPayload.java
@@ -1,0 +1,25 @@
+package appeng.core.network.payload;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+
+import appeng.core.AppEng;
+
+public record SpatialCaptureC2SPayload(int containerId, BlockPos pos) implements CustomPacketPayload {
+    public static final Type<SpatialCaptureC2SPayload> TYPE =
+            new Type<>(AppEng.makeId("spatial_capture"));
+
+    public static final StreamCodec<FriendlyByteBuf, SpatialCaptureC2SPayload> STREAM_CODEC = StreamCodec.of(
+            (buf, payload) -> {
+                buf.writeVarInt(payload.containerId());
+                buf.writeBlockPos(payload.pos());
+            },
+            buf -> new SpatialCaptureC2SPayload(buf.readVarInt(), buf.readBlockPos()));
+
+    @Override
+    public Type<? extends CustomPacketPayload> type() {
+        return TYPE;
+    }
+}

--- a/src/main/java/appeng/core/network/payload/SpatialRestoreC2SPayload.java
+++ b/src/main/java/appeng/core/network/payload/SpatialRestoreC2SPayload.java
@@ -1,0 +1,25 @@
+package appeng.core.network.payload;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+
+import appeng.core.AppEng;
+
+public record SpatialRestoreC2SPayload(int containerId, BlockPos pos) implements CustomPacketPayload {
+    public static final Type<SpatialRestoreC2SPayload> TYPE =
+            new Type<>(AppEng.makeId("spatial_restore"));
+
+    public static final StreamCodec<FriendlyByteBuf, SpatialRestoreC2SPayload> STREAM_CODEC = StreamCodec.of(
+            (buf, payload) -> {
+                buf.writeVarInt(payload.containerId());
+                buf.writeBlockPos(payload.pos());
+            },
+            buf -> new SpatialRestoreC2SPayload(buf.readVarInt(), buf.readBlockPos()));
+
+    @Override
+    public Type<? extends CustomPacketPayload> type() {
+        return TYPE;
+    }
+}

--- a/src/main/java/appeng/menu/spatial/SpatialIOPortMenu.java
+++ b/src/main/java/appeng/menu/spatial/SpatialIOPortMenu.java
@@ -1,0 +1,73 @@
+package appeng.menu.spatial;
+
+import java.util.Objects;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.MenuType;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
+
+import appeng.api.implementations.items.ISpatialStorageCell;
+import appeng.blockentity.spatial.SpatialIOPortBlockEntity;
+import appeng.menu.AEBaseMenu;
+import appeng.menu.SlotSemantics;
+import appeng.menu.implementations.MenuTypeBuilder;
+
+public class SpatialIOPortMenu extends AEBaseMenu {
+    public static final MenuType<SpatialIOPortMenu> TYPE = MenuTypeBuilder
+            .create(SpatialIOPortMenu::new, SpatialIOPortBlockEntity.class)
+            .build("spatial_io_port");
+
+    private final SpatialIOPortBlockEntity port;
+
+    public SpatialIOPortMenu(int id, Inventory playerInventory, SpatialIOPortBlockEntity port) {
+        super(TYPE, id, playerInventory, Objects.requireNonNull(port, "port"));
+        this.port = port;
+
+        addSlot(new Slot(port.getInternalInventory().toContainer(), 0, 80, 35) {
+            @Override
+            public boolean mayPlace(ItemStack stack) {
+                return stack.getItem() instanceof ISpatialStorageCell;
+            }
+
+            @Override
+            public int getMaxStackSize(ItemStack stack) {
+                return 1;
+            }
+        }, SlotSemantics.MACHINE_INPUT);
+
+        addPlayerInventorySlots(playerInventory);
+    }
+
+    private void addPlayerInventorySlots(Inventory inventory) {
+        for (int row = 0; row < 3; row++) {
+            for (int col = 0; col < 9; col++) {
+                int slotIndex = col + row * 9 + 9;
+                int x = 8 + col * 18;
+                int y = 84 + row * 18;
+                addSlot(new Slot(inventory, slotIndex, x, y), SlotSemantics.PLAYER_INVENTORY);
+            }
+        }
+
+        for (int col = 0; col < 9; col++) {
+            int x = 8 + col * 18;
+            int y = 142;
+            addSlot(new Slot(inventory, col, x, y), SlotSemantics.PLAYER_HOTBAR);
+        }
+    }
+
+    public SpatialIOPortBlockEntity getBlockEntity() {
+        return port;
+    }
+
+    public BlockPos getBlockPos() {
+        return port.getBlockPos();
+    }
+
+    @Override
+    public boolean stillValid(Player player) {
+        return !port.isRemoved();
+    }
+}

--- a/src/main/java/appeng/registry/AE2BlockEntities.java
+++ b/src/main/java/appeng/registry/AE2BlockEntities.java
@@ -7,6 +7,7 @@ import appeng.blockentity.ControllerBlockEntity;
 import appeng.blockentity.EnergyAcceptorBlockEntity;
 import appeng.blockentity.InscriberBlockEntity;
 import appeng.blockentity.simple.DriveBlockEntity;
+import appeng.blockentity.spatial.SpatialIOPortBlockEntity;
 import appeng.blockentity.terminal.CraftingTerminalBlockEntity;
 import appeng.blockentity.crafting.PatternEncodingTerminalBlockEntity;
 import appeng.blockentity.terminal.PatternTerminalBlockEntity;
@@ -68,6 +69,11 @@ public final class AE2BlockEntities {
         AE2Registries.BLOCK_ENTITIES.register("crafting_monitor",
             () -> BlockEntityType.Builder.of(CraftingMonitorBlockEntity::new,
                 AE2Blocks.CRAFTING_MONITOR.get()).build(null));
+
+    public static final RegistryObject<BlockEntityType<SpatialIOPortBlockEntity>> SPATIAL_IO_PORT =
+        AE2Registries.BLOCK_ENTITIES.register("spatial_io_port",
+            () -> BlockEntityType.Builder.of(SpatialIOPortBlockEntity::new,
+                AE2Blocks.SPATIAL_IO_PORT.get()).build(null));
 
     private AE2BlockEntities() {}
 }

--- a/src/main/java/appeng/registry/AE2Blocks.java
+++ b/src/main/java/appeng/registry/AE2Blocks.java
@@ -21,6 +21,7 @@ import appeng.block.simple.DriveBlock;
 import appeng.block.terminal.CraftingTerminalBlock;
 import appeng.block.terminal.PatternTerminalBlock;
 import appeng.block.terminal.TerminalBlock;
+import appeng.block.spatial.SpatialIOPortBlock;
 
 public final class AE2Blocks {
     public static final RegistryObject<Block> CERTUS_QUARTZ_ORE = AE2Registries.BLOCKS.register(
@@ -80,6 +81,9 @@ public final class AE2Blocks {
 
     public static final RegistryObject<Block> CRAFTING_MONITOR = AE2Registries.BLOCKS.register("crafting_monitor",
             () -> new CraftingMonitorBlock(CraftingUnitType.MONITOR));
+
+    public static final RegistryObject<Block> SPATIAL_IO_PORT =
+        AE2Registries.BLOCKS.register("spatial_io_port", SpatialIOPortBlock::new);
 
     private AE2Blocks() {}
 }

--- a/src/main/java/appeng/registry/AE2Items.java
+++ b/src/main/java/appeng/registry/AE2Items.java
@@ -146,6 +146,10 @@ public final class AE2Items {
             "crafting_monitor",
             () -> new BlockItem(AE2Blocks.CRAFTING_MONITOR.get(), new Properties()));
 
+    public static final RegistryObject<Item> SPATIAL_IO_PORT = AE2Registries.ITEMS.register(
+            "spatial_io_port",
+            () -> new BlockItem(AE2Blocks.SPATIAL_IO_PORT.get(), new Properties()));
+
     public static final RegistryObject<Item> BLANK_PATTERN = AE2Registries.ITEMS.register(
             "blank_pattern",
             () -> new BlankPatternItem(new Properties()));

--- a/src/main/java/appeng/registry/AE2Menus.java
+++ b/src/main/java/appeng/registry/AE2Menus.java
@@ -8,6 +8,7 @@ import appeng.menu.terminal.CraftingTerminalMenu;
 import appeng.menu.implementations.PatternEncodingTerminalMenu;
 import appeng.menu.terminal.PatternTerminalMenu;
 import appeng.menu.simple.SimpleDriveMenu;
+import appeng.menu.spatial.SpatialIOPortMenu;
 import net.minecraft.world.inventory.MenuType;
 import net.neoforged.neoforge.registries.RegistryObject;
 
@@ -32,6 +33,9 @@ public final class AE2Menus {
 
     public static final RegistryObject<MenuType<SimpleDriveMenu>> SIMPLE_DRIVE_MENU =
         AE2Registries.MENUS.register("simple_drive", () -> SimpleDriveMenu.TYPE);
+
+    public static final RegistryObject<MenuType<SpatialIOPortMenu>> SPATIAL_IO_PORT_MENU =
+        AE2Registries.MENUS.register("spatial_io_port", () -> SpatialIOPortMenu.TYPE);
 
     private AE2Menus() {}
 }

--- a/src/main/resources/assets/ae2/blockstates/spatial_io_port.json
+++ b/src/main/resources/assets/ae2/blockstates/spatial_io_port.json
@@ -1,0 +1,6 @@
+{
+  "variants": {
+    "powered=false": { "model": "ae2:block/spatial_io_port" },
+    "powered=true": { "model": "ae2:block/spatial_io_port_on" }
+  }
+}

--- a/src/main/resources/assets/ae2/lang/en_us.json
+++ b/src/main/resources/assets/ae2/lang/en_us.json
@@ -1,0 +1,5 @@
+{
+  "block.ae2.spatial_io_port": "Spatial IO Port",
+  "gui.ae2.spatial.capture": "Capture",
+  "gui.ae2.spatial.restore": "Restore"
+}

--- a/src/main/resources/assets/ae2/models/item/spatial_io_port.json
+++ b/src/main/resources/assets/ae2/models/item/spatial_io_port.json
@@ -1,0 +1,3 @@
+{
+  "parent": "ae2:block/spatial_io_port"
+}

--- a/src/main/resources/data/ae2/loot_tables/blocks/spatial_io_port.json
+++ b/src/main/resources/data/ae2/loot_tables/blocks/spatial_io_port.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "ae2:spatial_io_port"
+        }
+      ],
+      "conditions": [
+        { "condition": "minecraft:survives_explosion" }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/ae2/recipe/spatial_io_port.json
+++ b/src/main/resources/data/ae2/recipe/spatial_io_port.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "IRI",
+    "CGC",
+    "IRI"
+  ],
+  "key": {
+    "I": { "item": "minecraft:iron_ingot" },
+    "R": { "item": "minecraft:redstone" },
+    "C": { "item": "minecraft:chest" },
+    "G": { "item": "minecraft:glass" }
+  },
+  "result": {
+    "item": "ae2:spatial_io_port"
+  }
+}

--- a/src/test/java/appeng/spatial/SpatialIOPortTest.java
+++ b/src/test/java/appeng/spatial/SpatialIOPortTest.java
@@ -1,0 +1,59 @@
+package appeng.spatial;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.state.BlockState;
+
+import appeng.blockentity.spatial.SpatialIOPortBlockEntity;
+import appeng.items.storage.spatial.SpatialCellItem;
+import appeng.registry.AE2Blocks;
+import appeng.util.BootstrapMinecraftExtension;
+
+@ExtendWith(BootstrapMinecraftExtension.class)
+class SpatialIOPortTest {
+    private SpatialIOPortBlockEntity blockEntity;
+
+    @BeforeEach
+    void setUp() {
+        BlockState state = AE2Blocks.SPATIAL_IO_PORT.get().defaultBlockState();
+        blockEntity = new SpatialIOPortBlockEntity(BlockPos.ZERO, state);
+    }
+
+    @Test
+    void captureAndRestoreStubsAreCallable() {
+        blockEntity.captureRegion();
+        blockEntity.restoreRegion();
+
+        blockEntity.getInternalInventory().setItemDirect(0, new ItemStack(new TestSpatialCellItem(2)));
+        blockEntity.captureRegion();
+        blockEntity.restoreRegion();
+    }
+
+    @Test
+    void regionSizeMatchesCellTier() {
+        blockEntity.getInternalInventory().setItemDirect(0, new ItemStack(new TestSpatialCellItem(2)));
+        assertEquals(new BlockPos(2, 2, 2), blockEntity.getRegionSize());
+
+        blockEntity.getInternalInventory().setItemDirect(0, new ItemStack(new TestSpatialCellItem(16)));
+        assertEquals(new BlockPos(16, 16, 16), blockEntity.getRegionSize());
+
+        blockEntity.getInternalInventory().setItemDirect(0, new ItemStack(new TestSpatialCellItem(128)));
+        assertEquals(new BlockPos(128, 128, 128), blockEntity.getRegionSize());
+
+        blockEntity.getInternalInventory().setItemDirect(0, new ItemStack(new TestSpatialCellItem(512)));
+        assertEquals(new BlockPos(512, 512, 512), blockEntity.getRegionSize());
+    }
+
+    private static final class TestSpatialCellItem extends SpatialCellItem {
+        TestSpatialCellItem(int size) {
+            super(new Item.Properties(), size);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a simplified Spatial IO Port block entity with inventory handling, redstone triggers, and capture/restore stubs
- introduce a basic menu, screen, and networking payloads for manual capture/restore actions
- register the new block, block entity, menu, screen, resources, and add unit tests for region sizing logic

## Testing
- `./gradlew test` *(fails: missing legacy Minecraft/NeoForge classes during project compile)*

------
https://chatgpt.com/codex/tasks/task_e_68e481f73aa88327b4a718980f1b996a