### PR TITLE
Added Formation Plane scaffolding with block/entity, menu/screen, registration, datagen, and translations

### DIFF
--- a/src/main/java/appeng/api/ids/AEBlockIds.java
+++ b/src/main/java/appeng/api/ids/AEBlockIds.java
@@ -73,6 +73,7 @@ public final class AEBlockIds {
     public static final ResourceLocation LEVEL_EMITTER = id("level_emitter_block");
     public static final ResourceLocation IMPORT_BUS = id("import_bus");
     public static final ResourceLocation EXPORT_BUS = id("export_bus");
+    public static final ResourceLocation FORMATION_PLANE = id("formation_plane");
     public static final ResourceLocation CONDENSER = id("condenser");
     public static final ResourceLocation ENERGY_ACCEPTOR = id("energy_acceptor");
     public static final ResourceLocation CRYSTAL_RESONANCE_GENERATOR = id("crystal_resonance_generator");

--- a/src/main/java/appeng/block/io/FormationPlaneBlock.java
+++ b/src/main/java/appeng/block/io/FormationPlaneBlock.java
@@ -1,0 +1,43 @@
+package appeng.block.io;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.BlockHitResult;
+
+import appeng.api.orientation.IOrientationStrategy;
+import appeng.api.orientation.OrientationStrategies;
+import appeng.block.AEBaseEntityBlock;
+import appeng.blockentity.io.FormationPlaneBlockEntity;
+import appeng.menu.MenuOpener;
+import appeng.menu.implementations.FormationPlaneMenu;
+import appeng.menu.locator.MenuLocators;
+
+public class FormationPlaneBlock extends AEBaseEntityBlock<FormationPlaneBlockEntity> {
+
+    public FormationPlaneBlock() {
+        super(metalProps());
+    }
+
+    @Override
+    public IOrientationStrategy getOrientationStrategy() {
+        return OrientationStrategies.facing();
+    }
+
+    @Override
+    protected InteractionResult useWithoutItem(BlockState state, Level level, BlockPos pos, Player player,
+            BlockHitResult hitResult) {
+        var blockEntity = getBlockEntity(level, pos);
+        if (blockEntity != null) {
+            if (!level.isClientSide()) {
+                MenuOpener.open(FormationPlaneMenu.TYPE, player, MenuLocators.forBlockEntity(blockEntity));
+            }
+            return InteractionResult.sidedSuccess(level.isClientSide());
+        }
+
+        return super.useWithoutItem(state, level, pos, player, hitResult);
+    }
+}
+

--- a/src/main/java/appeng/blockentity/io/FormationPlaneBlockEntity.java
+++ b/src/main/java/appeng/blockentity/io/FormationPlaneBlockEntity.java
@@ -1,0 +1,84 @@
+package appeng.blockentity.io;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.BlockState;
+
+import appeng.api.config.FuzzyMode;
+import appeng.api.config.Setting;
+import appeng.api.config.Settings;
+import appeng.api.config.YesNo;
+import appeng.api.networking.GridFlags;
+import appeng.api.upgrades.IUpgradeInventory;
+import appeng.api.upgrades.UpgradeInventories;
+import appeng.api.util.IConfigManager;
+import appeng.blockentity.grid.AENetworkedBlockEntity;
+import appeng.core.definitions.AEBlocks;
+import appeng.menu.implementations.FormationPlaneMenuHost;
+import appeng.util.ConfigInventory;
+
+public class FormationPlaneBlockEntity extends AENetworkedBlockEntity implements FormationPlaneMenuHost {
+
+    private final ConfigInventory config = ConfigInventory.configTypes(63)
+            .changeListener(this::onConfigChanged)
+            .build();
+
+    private final IConfigManager configManager = IConfigManager.builder(this::onSettingChanged)
+            .registerSetting(Settings.PLACE_BLOCK, YesNo.YES)
+            .registerSetting(Settings.FUZZY_MODE, FuzzyMode.IGNORE_ALL)
+            .build();
+
+    private final IUpgradeInventory upgrades = UpgradeInventories
+            .forMachine(AEBlocks.FORMATION_PLANE, 5, this::onUpgradesChanged);
+
+    public FormationPlaneBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
+        super(type, pos, state);
+        getMainNode().setFlags(GridFlags.REQUIRE_CHANNEL);
+    }
+
+    private void onConfigChanged() {
+        setChanged();
+    }
+
+    private void onSettingChanged(IConfigManager manager, Setting<?> setting) {
+        setChanged();
+    }
+
+    private void onUpgradesChanged() {
+        setChanged();
+    }
+
+    @Override
+    public ConfigInventory getConfig() {
+        return config;
+    }
+
+    @Override
+    public IConfigManager getConfigManager() {
+        return configManager;
+    }
+
+    @Override
+    public IUpgradeInventory getUpgrades() {
+        return upgrades;
+    }
+
+    @Override
+    public void saveAdditional(CompoundTag data, HolderLookup.Provider registries) {
+        super.saveAdditional(data, registries);
+        config.writeToChildTag(data, "config", registries);
+        configManager.writeToNBT(data, registries);
+        upgrades.writeToNBT(data, "upgrades", registries);
+    }
+
+    @Override
+    public void loadTag(CompoundTag data, HolderLookup.Provider registries) {
+        super.loadTag(data, registries);
+        config.readFromChildTag(data, "config", registries);
+        configManager.readFromNBT(data, registries);
+        upgrades.readFromNBT(data, "upgrades", registries);
+    }
+}
+

--- a/src/main/java/appeng/core/definitions/AEBlockEntities.java
+++ b/src/main/java/appeng/core/definitions/AEBlockEntities.java
@@ -44,6 +44,7 @@ import appeng.blockentity.crafting.CraftingMonitorBlockEntity;
 import appeng.blockentity.crafting.MolecularAssemblerBlockEntity;
 import appeng.blockentity.crafting.PatternProviderBlockEntity;
 import appeng.blockentity.io.ExportBusBlockEntity;
+import appeng.blockentity.io.FormationPlaneBlockEntity;
 import appeng.blockentity.io.ImportBusBlockEntity;
 import appeng.blockentity.misc.CellWorkbenchBlockEntity;
 import appeng.blockentity.misc.ChargerBlockEntity;
@@ -127,6 +128,8 @@ public final class AEBlockEntities {
             ImportBusBlockEntity.class, ImportBusBlockEntity::new, AEBlocks.IMPORT_BUS);
     public static final DeferredBlockEntityType<ExportBusBlockEntity> EXPORT_BUS = create("export_bus",
             ExportBusBlockEntity.class, ExportBusBlockEntity::new, AEBlocks.EXPORT_BUS);
+    public static final DeferredBlockEntityType<FormationPlaneBlockEntity> FORMATION_PLANE = create("formation_plane",
+            FormationPlaneBlockEntity.class, FormationPlaneBlockEntity::new, AEBlocks.FORMATION_PLANE);
     public static final DeferredBlockEntityType<CondenserBlockEntity> CONDENSER = create("condenser",
             CondenserBlockEntity.class,
             CondenserBlockEntity::new, AEBlocks.CONDENSER);

--- a/src/main/java/appeng/core/definitions/AEBlocks.java
+++ b/src/main/java/appeng/core/definitions/AEBlocks.java
@@ -67,6 +67,7 @@ import appeng.block.misc.CrankBlock;
 import appeng.block.misc.GrowthAcceleratorBlock;
 import appeng.block.misc.InscriberBlock;
 import appeng.block.io.ExportBusBlock;
+import appeng.block.io.FormationPlaneBlock;
 import appeng.block.io.ImportBusBlock;
 import appeng.block.misc.InterfaceBlock;
 import appeng.block.misc.LevelEmitterBlock;
@@ -192,6 +193,8 @@ public final class AEBlocks {
             ImportBusBlock::new);
     public static final BlockDefinition<ExportBusBlock> EXPORT_BUS = block("ME Export Bus", AEBlockIds.EXPORT_BUS,
             ExportBusBlock::new);
+    public static final BlockDefinition<FormationPlaneBlock> FORMATION_PLANE = block("Formation Plane",
+            AEBlockIds.FORMATION_PLANE, FormationPlaneBlock::new);
     public static final BlockDefinition<CondenserBlock> CONDENSER = block("Matter Condenser", AEBlockIds.CONDENSER, CondenserBlock::new);
     public static final BlockDefinition<EnergyAcceptorBlock> ENERGY_ACCEPTOR = block("Energy Acceptor", AEBlockIds.ENERGY_ACCEPTOR, EnergyAcceptorBlock::new);
     public static final BlockDefinition<CrystalResonanceGeneratorBlock> CRYSTAL_RESONANCE_GENERATOR = block("Crystal Resonance Generator", AEBlockIds.CRYSTAL_RESONANCE_GENERATOR, CrystalResonanceGeneratorBlock::new);

--- a/src/main/java/appeng/datagen/AE2BlockStateProvider.java
+++ b/src/main/java/appeng/datagen/AE2BlockStateProvider.java
@@ -22,6 +22,8 @@ public class AE2BlockStateProvider extends BlockStateProvider {
         simpleBlock(AE2Blocks.ENERGY_ACCEPTOR.get());
         simpleBlock(AE2Blocks.CABLE.get());
         simpleBlock(AE2Blocks.CRAFTING_MONITOR.get());
+        directionalBlock(AE2Blocks.FORMATION_PLANE.get(),
+                models().cubeAll("formation_plane", modLoc("block/formation_plane")));
         // TODO(PR-36): Replace simple models with directional variants once the NeoForge port hooks
         // up blockstate properties for terminals and drives.
         simpleBlock(AE2Blocks.DRIVE.get());

--- a/src/main/java/appeng/datagen/AE2BlockTagsProvider.java
+++ b/src/main/java/appeng/datagen/AE2BlockTagsProvider.java
@@ -18,6 +18,8 @@ import appeng.registry.AE2Blocks;
 public class AE2BlockTagsProvider extends BlockTagsProvider {
     private static final TagKey<Block> METEORITE_REPLACEABLE = TagKey.create(Registries.BLOCK,
             new ResourceLocation(AE2Registries.MODID, "meteorite_replaceable"));
+    private static final TagKey<Block> IO_PLANES = TagKey.create(Registries.BLOCK,
+            new ResourceLocation(AE2Registries.MODID, "io_planes"));
 
     public AE2BlockTagsProvider(PackOutput output,
             CompletableFuture<HolderLookup.Provider> lookup,
@@ -41,10 +43,13 @@ public class AE2BlockTagsProvider extends BlockTagsProvider {
                 .add(AE2Blocks.CRAFTING_TERMINAL.get())
                 .add(AE2Blocks.PATTERN_TERMINAL.get())
                 .add(AE2Blocks.PATTERN_ENCODING_TERMINAL.get())
-                .add(AE2Blocks.CRAFTING_MONITOR.get());
+                .add(AE2Blocks.CRAFTING_MONITOR.get())
+                .add(AE2Blocks.FORMATION_PLANE.get());
 
         tag(METEORITE_REPLACEABLE)
                 .addTag(BlockTags.STONE_ORE_REPLACEABLES)
                 .addTag(BlockTags.DEEPSLATE_ORE_REPLACEABLES);
+
+        tag(IO_PLANES).add(AE2Blocks.FORMATION_PLANE.get());
     }
 }

--- a/src/main/java/appeng/datagen/AE2ItemModelProvider.java
+++ b/src/main/java/appeng/datagen/AE2ItemModelProvider.java
@@ -28,6 +28,7 @@ public class AE2ItemModelProvider extends ItemModelProvider {
         withExistingParent(AE2Items.PATTERN_TERMINAL.getId().getPath(), modLoc("block/pattern_terminal"));
         withExistingParent(AE2Items.PATTERN_ENCODING_TERMINAL_BLOCK.getId().getPath(),
                 modLoc("block/pattern_encoding_terminal"));
+        withExistingParent(AE2Items.FORMATION_PLANE.getId().getPath(), modLoc("block/formation_plane"));
 
         basicItem(AE2Items.SILICON.get());
         basicItem(AE2Items.CERTUS_QUARTZ_CRYSTAL.get());

--- a/src/main/java/appeng/datagen/AE2ItemTagsProvider.java
+++ b/src/main/java/appeng/datagen/AE2ItemTagsProvider.java
@@ -23,6 +23,8 @@ public class AE2ItemTagsProvider extends ItemTagsProvider {
     private static final TagKey<Item> TERMINALS = tag("terminals");
     private static final TagKey<Item> CABLES = tag("cables");
     private static final TagKey<Item> MONITORS = tag("monitors");
+    private static final TagKey<Item> AUTOMATION = tag("automation");
+    private static final TagKey<Item> IO_PLANES = tag("io_planes");
     private static final TagKey<Item> FORGE_SILICON = forgeTag("silicon");
     private static final TagKey<Item> COMMON_SILICON = commonTag("silicon");
     private static final TagKey<Item> FORGE_PROCESSORS = forgeTag("processors");
@@ -75,6 +77,9 @@ public class AE2ItemTagsProvider extends ItemTagsProvider {
 
         // Mirrors the mainline "monitors" tag so downstream integrations can share recipes/config.
         tag(MONITORS).add(AE2Items.CRAFTING_MONITOR.get());
+
+        tag(AUTOMATION).add(AE2Items.FORMATION_PLANE.get());
+        tag(IO_PLANES).add(AE2Items.FORMATION_PLANE.get());
     }
 
     private static TagKey<Item> tag(String path) {

--- a/src/main/java/appeng/datagen/AE2LootTableProvider.java
+++ b/src/main/java/appeng/datagen/AE2LootTableProvider.java
@@ -96,6 +96,13 @@ public class AE2LootTableProvider extends LootTableProvider {
                             LootPool.lootPool().setRolls(ConstantValue.exactly(1))
                                     .add(LootItem.lootTableItem(AE2Blocks.CRAFTING_MONITOR.get()))));
 
+            out.accept(AE2Blocks.FORMATION_PLANE.getId(),
+                    LootTable.lootTable().withPool(
+                            LootPool.lootPool().setRolls(ConstantValue.exactly(1))
+                                    .add(LootItem.lootTableItem(AE2Blocks.FORMATION_PLANE.get())
+                                            .apply(CopyComponentsFunction.copyComponents(
+                                                    CopyComponentsFunction.Source.BLOCK_ENTITY)))));
+
             out.accept(AE2Blocks.SKY_STONE_CHEST.getId(),
                     LootTable.lootTable().withPool(
                             LootPool.lootPool().setRolls(ConstantValue.exactly(1))

--- a/src/main/java/appeng/datagen/AE2RecipeProvider.java
+++ b/src/main/java/appeng/datagen/AE2RecipeProvider.java
@@ -102,6 +102,17 @@ public class AE2RecipeProvider extends RecipeProvider {
                 .unlockedBy("has_calculation_processor", has(AE2Items.CALCULATION_PROCESSOR.get()))
                 .save(output, new ResourceLocation(AE2Registries.MODID, "crafting/fuzzy_card"));
 
+        ShapedRecipeBuilder.shaped(RecipeCategory.MISC, AE2Items.FORMATION_PLANE.get())
+                .pattern("CGC")
+                .pattern("ILI")
+                .pattern("CGC")
+                .define('C', AE2Items.CABLE.get())
+                .define('G', Items.GLASS)
+                .define('I', Items.IRON_INGOT)
+                .define('L', AE2Items.LOGIC_PROCESSOR.get())
+                .unlockedBy("has_logic_processor", has(AE2Items.LOGIC_PROCESSOR.get()))
+                .save(output, new ResourceLocation(AE2Registries.MODID, "crafting/formation_plane"));
+
         ShapelessRecipeBuilder.shapeless(RecipeCategory.MISC, AE2Items.PARTITIONED_CELL.get())
                 .requires(AE2Items.ENGINEERING_PROCESSOR.get())
                 .requires(AE2Items.BASIC_CELL_1K.get())

--- a/src/main/java/appeng/datagen/AELangProvider.java
+++ b/src/main/java/appeng/datagen/AELangProvider.java
@@ -27,6 +27,7 @@ public class AELangProvider extends LanguageProvider {
         add("block.appliedenergistics2.storage_bus", "ME Storage Bus");
         add("block.appliedenergistics2.import_bus", "ME Import Bus");
         add("block.appliedenergistics2.export_bus", "ME Export Bus");
+        add("block.appliedenergistics2.formation_plane", "Formation Plane");
         add("block.appliedenergistics2.cable", "Cable");
         add("block.appliedenergistics2.meteorite", "Meteorite");
         add("block.appliedenergistics2.meteorite_hint", "Meteorite Hint");
@@ -174,6 +175,7 @@ public class AELangProvider extends LanguageProvider {
         add("gui.appliedenergistics2.redstone.mode.short.active_with_signal", "With Signal");
         add("gui.appliedenergistics2.redstone.mode.short.active_without_signal", "Without Signal");
         add("gui.appliedenergistics2.redstone.mode.short.always_active", "Always");
+        add("screen.appliedenergistics2.formation_plane", "Formation Plane");
         add("gui.ae2.io_bus.transfer_cooldown", "Transfer cooldown: %s ticks");
         add("gui.ae2.io_bus.operations_per_transfer", "Operations per transfer: %s");
         add("gui.ae2.io_bus.filter_mode.whitelist", "Filter mode: Whitelist");

--- a/src/main/java/appeng/menu/implementations/FormationPlaneMenu.java
+++ b/src/main/java/appeng/menu/implementations/FormationPlaneMenu.java
@@ -28,22 +28,21 @@ import appeng.api.util.IConfigManager;
 import appeng.client.gui.implementations.FormationPlaneScreen;
 import appeng.core.definitions.AEItems;
 import appeng.menu.guisync.GuiSync;
-import appeng.parts.automation.FormationPlanePart;
 
 /**
  * @see FormationPlaneScreen
  */
-public class FormationPlaneMenu extends UpgradeableMenu<FormationPlanePart> {
+public class FormationPlaneMenu extends UpgradeableMenu<FormationPlaneMenuHost> {
 
     public static final MenuType<FormationPlaneMenu> TYPE = MenuTypeBuilder
-            .create(FormationPlaneMenu::new, FormationPlanePart.class)
+            .create(FormationPlaneMenu::new, FormationPlaneMenuHost.class)
             .build("formationplane");
 
     @GuiSync(7)
     public YesNo placeMode;
 
     public FormationPlaneMenu(MenuType<FormationPlaneMenu> type, int id, Inventory ip,
-            FormationPlanePart host) {
+            FormationPlaneMenuHost host) {
         super(type, id, ip, host);
     }
 

--- a/src/main/java/appeng/menu/implementations/FormationPlaneMenuHost.java
+++ b/src/main/java/appeng/menu/implementations/FormationPlaneMenuHost.java
@@ -1,0 +1,12 @@
+package appeng.menu.implementations;
+
+import appeng.api.upgrades.IUpgradeableObject;
+import appeng.api.util.IConfigurableObject;
+import appeng.helpers.IConfigInvHost;
+
+/**
+ * Shared host contract for the formation plane menu so both the part and block implementations can reuse the same UI.
+ */
+public interface FormationPlaneMenuHost extends IUpgradeableObject, IConfigInvHost, IConfigurableObject {
+}
+

--- a/src/main/java/appeng/parts/automation/FormationPlanePart.java
+++ b/src/main/java/appeng/parts/automation/FormationPlanePart.java
@@ -61,11 +61,13 @@ import appeng.items.parts.PartModels;
 import appeng.menu.ISubMenu;
 import appeng.menu.MenuOpener;
 import appeng.menu.implementations.FormationPlaneMenu;
+import appeng.menu.implementations.FormationPlaneMenuHost;
 import appeng.menu.locator.MenuLocators;
 import appeng.util.ConfigInventory;
 import appeng.util.prioritylist.IPartitionList;
 
-public class FormationPlanePart extends UpgradeablePart implements IStorageProvider, IPriorityHost, IConfigInvHost {
+public class FormationPlanePart extends UpgradeablePart
+        implements IStorageProvider, IPriorityHost, IConfigInvHost, FormationPlaneMenuHost {
 
     private static final PlaneModels MODELS = new PlaneModels("part/formation_plane",
             "part/formation_plane_on");

--- a/src/main/java/appeng/registry/AE2Blocks.java
+++ b/src/main/java/appeng/registry/AE2Blocks.java
@@ -21,6 +21,7 @@ import appeng.block.simple.DriveBlock;
 import appeng.block.terminal.CraftingTerminalBlock;
 import appeng.block.terminal.PatternTerminalBlock;
 import appeng.block.terminal.TerminalBlock;
+import appeng.block.io.FormationPlaneBlock;
 import appeng.block.spatial.SpatialIOPortBlock;
 
 public final class AE2Blocks {
@@ -84,6 +85,9 @@ public final class AE2Blocks {
 
     public static final RegistryObject<Block> SPATIAL_IO_PORT =
         AE2Registries.BLOCKS.register("spatial_io_port", SpatialIOPortBlock::new);
+
+    public static final RegistryObject<Block> FORMATION_PLANE =
+        AE2Registries.BLOCKS.register("formation_plane", FormationPlaneBlock::new);
 
     private AE2Blocks() {}
 }

--- a/src/main/java/appeng/registry/AE2Items.java
+++ b/src/main/java/appeng/registry/AE2Items.java
@@ -150,6 +150,10 @@ public final class AE2Items {
             "spatial_io_port",
             () -> new BlockItem(AE2Blocks.SPATIAL_IO_PORT.get(), new Properties()));
 
+    public static final RegistryObject<Item> FORMATION_PLANE = AE2Registries.ITEMS.register(
+            "formation_plane",
+            () -> new BlockItem(AE2Blocks.FORMATION_PLANE.get(), new Properties()));
+
     public static final RegistryObject<Item> BLANK_PATTERN = AE2Registries.ITEMS.register(
             "blank_pattern",
             () -> new BlankPatternItem(new Properties()));


### PR DESCRIPTION
## Summary
- add a Formation Plane block with a minimal grid-connected block entity and hook it into the existing menu via a shared host interface
- register the new block, block entity, and block item in both runtime and datagen registries so it appears in-game and on the creative tab
- extend datagen to cover blockstates, models, loot, recipe, tags, and language entries for the Formation Plane UI

## Testing
- `./gradlew clean build` *(fails: neoFormApplyOfficialMappings stage in this environment)*
- `./gradlew runData` *(fails: neoFormApplyOfficialMappings stage in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5361dfcb08327bc607a77dca6042f