### PR TITLE
Add Interface UI translations to datagen

### DIFF
--- a/src/main/java/appeng/datagen/AELangProvider.java
+++ b/src/main/java/appeng/datagen/AELangProvider.java
@@ -19,11 +19,13 @@ public class AELangProvider extends LanguageProvider {
         add("block.appliedenergistics2.controller", "Controller");
         add("block.appliedenergistics2.energy_acceptor", "Energy Acceptor");
         add("block.appliedenergistics2.crafting_monitor", "Crafting Monitor");
+        add("block.appliedenergistics2.interface", "ME Interface");
         add("block.ae2.drive", "ME Drive");
         add("block.ae2.terminal", "ME Terminal");
         add("block.ae2.crafting_terminal", "ME Crafting Terminal");
         add("block.ae2.pattern_terminal", "ME Pattern Terminal");
         add("block.ae2.pattern_encoding_terminal", "Pattern Encoding Terminal");
+        add("block.ae2.interface", "ME Interface");
         add("block.appliedenergistics2.storage_bus", "ME Storage Bus");
         add("block.appliedenergistics2.import_bus", "ME Import Bus");
         add("block.appliedenergistics2.export_bus", "ME Export Bus");
@@ -177,7 +179,12 @@ public class AELangProvider extends LanguageProvider {
         add("gui.appliedenergistics2.redstone.mode.short.active_without_signal", "Without Signal");
         add("gui.appliedenergistics2.redstone.mode.short.always_active", "Always");
         add("screen.appliedenergistics2.annihilation_plane", "Annihilation Plane");
+        add("screen.appliedenergistics2.interface", "Interface");
+        add("screen.ae2.interface", "Interface");
         add("screen.appliedenergistics2.formation_plane", "Formation Plane");
+        add("gui.ae2.Interface", "Interface");
+        add("gui.ae2.InterfaceInput", "Input");
+        add("gui.ae2.InterfaceOutput", "Output");
         add("gui.ae2.io_bus.transfer_cooldown", "Transfer cooldown: %s ticks");
         add("gui.ae2.io_bus.operations_per_transfer", "Operations per transfer: %s");
         add("gui.ae2.io_bus.filter_mode.whitelist", "Filter mode: Whitelist");

--- a/src/main/resources/assets/ae2/lang/en_us.json
+++ b/src/main/resources/assets/ae2/lang/en_us.json
@@ -13,6 +13,7 @@
   "log.ae2.spatial.capture_begin": "Capturing region %s³…",
   "log.ae2.spatial.restore_begin": "Restoring region %s³…",
   "tooltip.ae2.spatial.no_cell": "Insert a spatial cell to use this port",
+  "gui.ae2.Interface": "Interface",
   "gui.ae2.InterfaceInput": "Input",
   "gui.ae2.InterfaceOutput": "Output"
 }


### PR DESCRIPTION
## Summary
- add ME Interface block and screen translations to the AELangProvider so datagen emits the new keys
- record the Interface title/slot labels in the English language file to match the new menu layout

## Testing
- `./gradlew clean build` *(fails: sandbox is missing NeoForge/Minecraft client dependencies)*
- `./gradlew runData` *(fails: sandbox is missing NeoForge/Minecraft client dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e55036e3608327a601ec780ec347b3