### PR TITLE
Add version-specific recipe serialization handling

### DIFF
--- a/src/main/java/appeng/recipes/entropy/EntropyRecipeSerializer.java
+++ b/src/main/java/appeng/recipes/entropy/EntropyRecipeSerializer.java
@@ -20,8 +20,14 @@ package appeng.recipes.entropy;
 
 import com.mojang.serialization.MapCodec;
 
+//? if eval(current.version, "<=1.21.4") {
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+//? }
+//? if eval(current.version, ">=1.21.5") {
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
+//? }
 import net.minecraft.world.item.crafting.RecipeSerializer;
 
 public class EntropyRecipeSerializer implements RecipeSerializer<EntropyRecipe> {
@@ -31,8 +37,20 @@ public class EntropyRecipeSerializer implements RecipeSerializer<EntropyRecipe> 
         return EntropyRecipe.CODEC;
     }
 
+//? if eval(current.version, "<=1.21.4") {
+    @Override
+    public EntropyRecipe fromNetwork(ResourceLocation id, FriendlyByteBuf buffer) {
+        return EntropyRecipe.STREAM_CODEC.decode(buffer);
+    }
+
+    @Override
+    public void toNetwork(FriendlyByteBuf buffer, EntropyRecipe recipe) {
+        EntropyRecipe.STREAM_CODEC.encode(buffer, recipe);
+    }
+//? } else {
     @Override
     public StreamCodec<RegistryFriendlyByteBuf, EntropyRecipe> streamCodec() {
         return EntropyRecipe.STREAM_CODEC;
     }
+//? }
 }

--- a/src/main/java/appeng/recipes/handlers/InscriberRecipe.java
+++ b/src/main/java/appeng/recipes/handlers/InscriberRecipe.java
@@ -71,16 +71,17 @@ public class InscriberRecipe implements Recipe<RecipeInput> {
 //? if eval(current.version, "<=1.21.4") {
     // TODO(stonecutter): Validate FriendlyByteBuf variant against live 1.21.4 runtime once available.
     public static final StreamCodec<FriendlyByteBuf, InscriberRecipe> STREAM_CODEC = StreamCodec.composite(
-            Ingredients.STREAM_CODEC,
+            INGREDIENTS_STREAM_CODEC,
             InscriberRecipe::getSerializedIngredients,
             ItemStack.STREAM_CODEC,
             InscriberRecipe::getResultItem,
             NeoForgeStreamCodecs.enumCodec(InscriberProcessType.class),
             InscriberRecipe::getProcessType,
             InscriberRecipe::new);
-//? } else {
+//? }
+//? if eval(current.version, ">=1.21.5") {
     public static final StreamCodec<RegistryFriendlyByteBuf, InscriberRecipe> STREAM_CODEC = StreamCodec.composite(
-            Ingredients.STREAM_CODEC,
+            INGREDIENTS_STREAM_CODEC,
             InscriberRecipe::getSerializedIngredients,
             ItemStack.STREAM_CODEC,
             InscriberRecipe::getResultItem,
@@ -201,7 +202,13 @@ public class InscriberRecipe implements Recipe<RecipeInput> {
                         .forGetter(Ingredients::bottom))
                 .apply(builder, Ingredients::new));
 
-        public static final StreamCodec<RegistryFriendlyByteBuf, Ingredients> STREAM_CODEC = StreamCodec.composite(
+    }
+
+//? if eval(current.version, "<=1.21.4") {
+    private static final StreamCodec<FriendlyByteBuf, Ingredients> INGREDIENTS_STREAM_CODEC = createIngredientsStreamCodec();
+
+    private static StreamCodec<FriendlyByteBuf, Ingredients> createIngredientsStreamCodec() {
+        return StreamCodec.composite(
                 Ingredient.CONTENTS_STREAM_CODEC,
                 Ingredients::top,
                 Ingredient.CONTENTS_STREAM_CODEC,
@@ -210,5 +217,20 @@ public class InscriberRecipe implements Recipe<RecipeInput> {
                 Ingredients::bottom,
                 Ingredients::new);
     }
+//? }
+//? if eval(current.version, ">=1.21.5") {
+    private static final StreamCodec<RegistryFriendlyByteBuf, Ingredients> INGREDIENTS_STREAM_CODEC = createIngredientsStreamCodec();
+
+    private static StreamCodec<RegistryFriendlyByteBuf, Ingredients> createIngredientsStreamCodec() {
+        return StreamCodec.composite(
+                Ingredient.CONTENTS_STREAM_CODEC,
+                Ingredients::top,
+                Ingredient.CONTENTS_STREAM_CODEC,
+                Ingredients::middle,
+                Ingredient.CONTENTS_STREAM_CODEC,
+                Ingredients::bottom,
+                Ingredients::new);
+    }
+//? }
 
 }

--- a/src/main/java/appeng/recipes/mattercannon/MatterCannonAmmo.java
+++ b/src/main/java/appeng/recipes/mattercannon/MatterCannonAmmo.java
@@ -28,7 +28,9 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.NonNullList;
 import net.minecraft.data.recipes.RecipeOutput;
+//? if eval(current.version, "<=1.21.4") {
 import net.minecraft.network.FriendlyByteBuf;
+//? }
 //? if eval(current.version, ">=1.21.5") {
 import net.minecraft.network.RegistryFriendlyByteBuf;
 //? }

--- a/src/main/java/appeng/recipes/mattercannon/MatterCannonAmmoSerializer.java
+++ b/src/main/java/appeng/recipes/mattercannon/MatterCannonAmmoSerializer.java
@@ -20,8 +20,14 @@ package appeng.recipes.mattercannon;
 
 import com.mojang.serialization.MapCodec;
 
+//? if eval(current.version, "<=1.21.4") {
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+//? }
+//? if eval(current.version, ">=1.21.5") {
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
+//? }
 import net.minecraft.world.item.crafting.RecipeSerializer;
 
 public class MatterCannonAmmoSerializer implements RecipeSerializer<MatterCannonAmmo> {
@@ -31,8 +37,20 @@ public class MatterCannonAmmoSerializer implements RecipeSerializer<MatterCannon
         return MatterCannonAmmo.CODEC;
     }
 
+//? if eval(current.version, "<=1.21.4") {
+    @Override
+    public MatterCannonAmmo fromNetwork(ResourceLocation id, FriendlyByteBuf buffer) {
+        return MatterCannonAmmo.STREAM_CODEC.decode(buffer);
+    }
+
+    @Override
+    public void toNetwork(FriendlyByteBuf buffer, MatterCannonAmmo recipe) {
+        MatterCannonAmmo.STREAM_CODEC.encode(buffer, recipe);
+    }
+//? } else {
     @Override
     public StreamCodec<RegistryFriendlyByteBuf, MatterCannonAmmo> streamCodec() {
         return MatterCannonAmmo.STREAM_CODEC;
     }
+//? }
 }


### PR DESCRIPTION
## Summary
- add Stonecutter-guarded imports and stream codec wiring for entropy recipes
- split inscriber and matter cannon serialization logic to legacy and modern buffer codecs

## Testing
- `./gradlew :1.21.4:clean :1.21.4:compileJava` *(fails: missing net.neoforged:minecraft-dependencies:1.21.4)*
- `./gradlew :1.21.5:clean :1.21.5:compileJava` *(fails: missing net.neoforged:minecraft-dependencies:1.21.4)*

------
https://chatgpt.com/codex/tasks/task_b_68e688882434832fb63ae50c3c18d3e6