### PR TITLE
Gate worldgen and loot by NeoForge version

### DIFF
--- a/src/generated/resources/data/ae2/loot_modifiers/_placeholder.json
+++ b/src/generated/resources/data/ae2/loot_modifiers/_placeholder.json
@@ -1,0 +1,3 @@
+{
+  "comment": "Datagen replaces this stub."
+}

--- a/src/generated/resources/data/ae2/worldgen/biome_modifier/_placeholder.json
+++ b/src/generated/resources/data/ae2/worldgen/biome_modifier/_placeholder.json
@@ -1,0 +1,3 @@
+{
+  "comment": "Datagen replaces this stub."
+}

--- a/src/main/java/appeng/core/AppEngBase.java
+++ b/src/main/java/appeng/core/AppEngBase.java
@@ -88,7 +88,9 @@ import appeng.server.services.ChunkLoadingService;
 import appeng.server.testworld.GameTestPlotAdapter;
 import appeng.spatial.SpatialStorageChunkGenerator;
 import appeng.spatial.SpatialStorageDimensionIds;
+//? if eval(current.version, ">=1.21.4") {
 import appeng.registry.AE2LootModifiers;
+//? }
 import appeng.registry.AE2Registries;
 
 /**
@@ -126,7 +128,9 @@ public abstract class AppEngBase implements AppEng {
         AEParts.init();
         AE2Registries.register(modEventBus);
         AE2Registries.FEATURES.register(modEventBus);
+        //? if eval(current.version, ">=1.21.4") {
         AE2LootModifiers.init();
+        //? }
         AE2RecipeSerializers.init();
         AE2RecipeTypes.init();
         AE2Conditions.init();

--- a/src/main/java/appeng/data/AE2DataGen.java
+++ b/src/main/java/appeng/data/AE2DataGen.java
@@ -17,9 +17,11 @@ import appeng.datagen.AE2ItemModelProvider;
 import appeng.datagen.AE2ItemTagsProvider;
 import appeng.datagen.AE2LootTableProvider;
 import appeng.datagen.AE2RecipeProvider;
+//? if eval(current.version, ">=1.21.4") {
 import appeng.datagen.AE2WorldgenProvider;
-import appeng.datagen.AELangProvider;
 import appeng.datagen.AE2BiomeModifierProvider;
+//? }
+import appeng.datagen.AELangProvider;
 import appeng.datagen.ChargerRecipeProvider;
 import appeng.datagen.InscriberRecipeProvider;
 import appeng.datagen.ProcessingMachineRegistryProvider;
@@ -45,8 +47,10 @@ public final class AE2DataGen {
             generator.addProvider(true, new AE2ItemTagsProvider(packOutput, lookup, existing));
 
             generator.addProvider(true, new AE2LootTableProvider(packOutput));
+            //? if eval(current.version, ">=1.21.4") {
             generator.addProvider(true, new AE2WorldgenProvider(packOutput, lookup));
             generator.addProvider(true, new AE2BiomeModifierProvider(packOutput, lookup));
+            //? }
 
             generator.addProvider(true, new AE2RecipeProvider(packOutput));
             generator.addProvider(true, new ChargerRecipeProvider(packOutput));

--- a/src/main/java/appeng/data/providers/AELootModifierProvider.java
+++ b/src/main/java/appeng/data/providers/AELootModifierProvider.java
@@ -1,3 +1,4 @@
+//? if eval(current.version, ">=1.21.4") {
 package appeng.data.providers;
 
 import java.util.concurrent.CompletableFuture;
@@ -26,3 +27,4 @@ public final class AELootModifierProvider extends GlobalLootModifierProvider {
                 LootItemRandomChanceCondition.randomChance(0.35f).build() }));
     }
 }
+//? }

--- a/src/main/java/appeng/datagen/AE2BiomeModifierProvider.java
+++ b/src/main/java/appeng/datagen/AE2BiomeModifierProvider.java
@@ -1,3 +1,4 @@
+//? if eval(current.version, ">=1.21.4") {
 package appeng.datagen;
 
 import java.util.Set;
@@ -53,3 +54,4 @@ public class AE2BiomeModifierProvider extends DatapackBuiltinEntriesProvider {
             GenerationStep.Decoration.SURFACE_STRUCTURES));
     }
 }
+//? }

--- a/src/main/java/appeng/datagen/AE2WorldgenProvider.java
+++ b/src/main/java/appeng/datagen/AE2WorldgenProvider.java
@@ -1,3 +1,4 @@
+//? if eval(current.version, ">=1.21.4") {
 package appeng.datagen;
 
 import java.util.List;
@@ -81,3 +82,4 @@ public class AE2WorldgenProvider extends DatapackBuiltinEntriesProvider {
         context.register(AE2Features.METEORITE_PLACED, new PlacedFeature(meteorite, meteoritePlacement));
     }
 }
+//? }

--- a/src/main/java/appeng/loot/AE2CertusLootModifier.java
+++ b/src/main/java/appeng/loot/AE2CertusLootModifier.java
@@ -1,3 +1,4 @@
+//? if eval(current.version, ">=1.21.4") {
 package appeng.loot;
 
 import java.util.Set;
@@ -53,3 +54,4 @@ public class AE2CertusLootModifier extends LootModifier {
         return generatedLoot;
     }
 }
+//? }

--- a/src/main/java/appeng/loot/AE2PressLootModifier.java
+++ b/src/main/java/appeng/loot/AE2PressLootModifier.java
@@ -1,3 +1,4 @@
+//? if eval(current.version, ">=1.21.4") {
 package appeng.loot;
 
 import java.util.List;
@@ -72,3 +73,4 @@ public class AE2PressLootModifier extends LootModifier {
         generatedLoot.add(press);
     }
 }
+//? }

--- a/src/main/java/appeng/registry/AE2LootModifiers.java
+++ b/src/main/java/appeng/registry/AE2LootModifiers.java
@@ -1,3 +1,4 @@
+//? if eval(current.version, ">=1.21.4") {
 package appeng.registry;
 
 import com.mojang.serialization.Codec;
@@ -22,3 +23,4 @@ public final class AE2LootModifiers {
         // Intentionally empty to force the class to load and register modifiers.
     }
 }
+//? }

--- a/src/main/java/appeng/worldgen/AE2Features.java
+++ b/src/main/java/appeng/worldgen/AE2Features.java
@@ -9,21 +9,31 @@ import net.minecraft.world.level.levelgen.placement.PlacedFeature;
 import appeng.core.AppEng;
 
 public final class AE2Features {
-    public static final ResourceKey<ConfiguredFeature<?, ?>> CERTUS_QUARTZ_ORE =
-        ResourceKey.create(Registries.CONFIGURED_FEATURE,
-            new ResourceLocation(AppEng.MOD_ID, "certus_quartz_ore"));
+    //? if eval(current.version, ">=1.21.4") {
+    public static final ResourceKey<ConfiguredFeature<?, ?>> CERTUS_QUARTZ_ORE = ResourceKey.create(
+            Registries.CONFIGURED_FEATURE, new ResourceLocation(AppEng.MOD_ID, "certus_quartz_ore"));
 
-    public static final ResourceKey<PlacedFeature> CERTUS_QUARTZ_ORE_PLACED =
-        ResourceKey.create(Registries.PLACED_FEATURE,
-            new ResourceLocation(AppEng.MOD_ID, "certus_quartz_ore"));
+    public static final ResourceKey<PlacedFeature> CERTUS_QUARTZ_ORE_PLACED = ResourceKey.create(
+            Registries.PLACED_FEATURE, new ResourceLocation(AppEng.MOD_ID, "certus_quartz_ore"));
 
-    public static final ResourceKey<ConfiguredFeature<?, ?>> METEORITE =
-        ResourceKey.create(Registries.CONFIGURED_FEATURE,
-            new ResourceLocation(AppEng.MOD_ID, "meteorite"));
+    public static final ResourceKey<ConfiguredFeature<?, ?>> METEORITE = ResourceKey.create(
+            Registries.CONFIGURED_FEATURE, new ResourceLocation(AppEng.MOD_ID, "meteorite"));
 
-    public static final ResourceKey<PlacedFeature> METEORITE_PLACED =
-        ResourceKey.create(Registries.PLACED_FEATURE,
-            new ResourceLocation(AppEng.MOD_ID, "meteorite"));
+    public static final ResourceKey<PlacedFeature> METEORITE_PLACED = ResourceKey.create(
+            Registries.PLACED_FEATURE, new ResourceLocation(AppEng.MOD_ID, "meteorite"));
+    //? } else {
+    public static final ResourceKey<ConfiguredFeature<?, ?>> CERTUS_QUARTZ_ORE = ResourceKey.create(
+            Registries.CONFIGURED_FEATURE, new ResourceLocation(AppEng.MOD_ID, "certus_quartz_ore"));
+
+    public static final ResourceKey<PlacedFeature> CERTUS_QUARTZ_ORE_PLACED = ResourceKey.create(
+            Registries.PLACED_FEATURE, new ResourceLocation(AppEng.MOD_ID, "certus_quartz_ore"));
+
+    public static final ResourceKey<ConfiguredFeature<?, ?>> METEORITE = ResourceKey.create(
+            Registries.CONFIGURED_FEATURE, new ResourceLocation(AppEng.MOD_ID, "meteorite"));
+
+    public static final ResourceKey<PlacedFeature> METEORITE_PLACED = ResourceKey.create(
+            Registries.PLACED_FEATURE, new ResourceLocation(AppEng.MOD_ID, "meteorite"));
+    //? }
 
     private AE2Features() {}
 }

--- a/src/main/resources/data/ae2/worldgen/biome_modifier/add_certus_quartz_ore.json
+++ b/src/main/resources/data/ae2/worldgen/biome_modifier/add_certus_quartz_ore.json
@@ -1,0 +1,8 @@
+{
+  "type": "neoforge:add_features",
+  "biomes": "#minecraft:is_overworld",
+  "features": [
+    "ae2:certus_quartz_ore"
+  ],
+  "step": "underground_ores"
+}

--- a/src/main/resources/data/ae2/worldgen/biome_modifier/add_meteorites_overworld.json
+++ b/src/main/resources/data/ae2/worldgen/biome_modifier/add_meteorites_overworld.json
@@ -1,0 +1,8 @@
+{
+  "type": "neoforge:add_features",
+  "biomes": "#minecraft:is_overworld",
+  "features": [
+    "ae2:meteorite"
+  ],
+  "step": "surface_structures"
+}


### PR DESCRIPTION
## Summary
- wrap loot modifier registration and datagen in 1.21.4+ stonecutter guards while leaving older JSON-only paths untouched
- add version-gated worldgen provider wiring and minimal biome modifier JSONs for feature placement
- seed generated resource directories with placeholders expected by runtime loaders

## Testing
- `./gradlew clean compileJava` *(fails: Could not resolve net.neoforged:minecraft-dependencies:1.21.4 when stonecutter attempted the 1.21.1 build)*

------
https://chatgpt.com/codex/tasks/task_b_68e6918f37c4832fb25bd3a4f44b5a05